### PR TITLE
chore: update tox matrix to ansible 2.20/2.21, python 3.12/3.13

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ on:
       - extensions/molecule/**
       - galaxy.yml
       - requirements.yml
-      - tox-ini
+      - tox-ansible.ini
   push:
     paths:
       - collections/ansible_collections/calaviaorg/setup/playbooks/**
@@ -24,7 +24,7 @@ on:
       - extensions/molecule/**
       - galaxy.yml
       - requirements.yml
-      - tox-ini
+      - tox-ansible.ini
 jobs:
   tox-matrix:
     runs-on: ubuntu-latest

--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -1,10 +1,10 @@
 [ansible]
 skip =
     devel
-    milestone
     2.16
     2.17
     2.18
+    2.19
     py3.10
     py3.11
     py3.14


### PR DESCRIPTION
Updates the test matrix to focus on current and latest stable versions.

**Matrix changes:**
- Ansible 2.19 → skipped
- Ansible 2.20 → active (current stable)
- Ansible milestone (≈2.21) → active (latest, was previously skipped)
- Python 3.10/3.11 → skipped
- Python 3.12 → active (current stable)
- Python 3.13 → active (latest)
- Python 3.14 → skipped

**Result: 8 environments** (4 combinations × 2 test types)
```
integration-py3.12-2.20   integration-py3.13-2.20
integration-py3.12-milestone  integration-py3.13-milestone
unit-py3.12-2.20         unit-py3.13-2.20
unit-py3.12-milestone    unit-py3.13-milestone
```