### PR TITLE
feat: add GPG role with key management and agent configuration

### DIFF
--- a/collections/ansible_collections/calaviaorg/setup/README.md
+++ b/collections/ansible_collections/calaviaorg/setup/README.md
@@ -8,6 +8,7 @@ Ansible collection for setting up local development environments.
 |------|-------------|
 | [tmux](./roles/tmux/README.md) | Install and configure tmux with TPM plugin management |
 | [git](./roles/git/README.md) | Install and configure git with LFS support |
+| [gpg](./roles/gpg/README.md) | Install and manage GPG keys, agent, and SSH integration |
 | [vim](./roles/vim/README.md) | Install and configure vim |
 
 ## Requirements

--- a/collections/ansible_collections/calaviaorg/setup/roles/git/meta/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/git/meta/main.yml
@@ -16,4 +16,7 @@ galaxy_info:
     - tmux
     - sysops
 
-dependencies: []
+dependencies:
+  - role: gpg
+    gpg_skip_configure: true
+    gpg_key_manage: false

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/README.md
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/README.md
@@ -1,0 +1,96 @@
+# gpg
+
+Install and manage GPG keys and agent configuration.
+
+## Requirements
+
+- Ansible 2.19+
+- `pkg` or `brew` package manager (platform-dependent)
+
+## Role Variables
+
+### Installation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `gpg_installer` | `pkg` | Package manager to use: `pkg` or `brew` |
+| `gpg_privilege_escalation` | `true` | Use `become` for package installation |
+| `gpg_os_pkgs` | `[gnupg, pinentry-tty]` | OS packages to install |
+
+### Agent config
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `gpg_agent_config` | `~/.gnupg/gpg-agent.conf` | Path to gpg-agent configuration file |
+| `gpg_agent_ssh_support` | `true` | Enable SSH support in gpg-agent |
+| `gpg_agent_cache_ttl` | `600` | Cache TTL for GPG passphrase (seconds) |
+| `gpg_agent_pinentry` | `''` | Path to pinentry program (empty = default) |
+| `gpg_skip_configure` | `false` | Skip gpg-agent configuration entirely |
+
+### Key management
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `gpg_key_manage` | `false` | Enable key generation/import |
+| `gpg_key_type` | `RSA` | Key type (e.g. RSA, ECC) |
+| `gpg_key_length` | `4096` | Key length in bits |
+| `gpg_key_real_name` | `{{ git_user_name }}` | Real name for key generation |
+| `gpg_key_email` | `{{ git_user_email }}` | Email for key generation |
+| `gpg_key_passphrase` | `''` | Passphrase for key (empty = no passphrase) |
+| `gpg_key_import_file` | `''` | Path to existing key file to import |
+| `gpg_key_export_public` | `false` | Export public key after generation |
+| `gpg_key_export_path` | `~/.gnupg/public.key` | Path to export public key |
+
+### SSH
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `gpg_ssh_control_keys` | `[]` | List of keygrips to add to sshcontrol |
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: all
+  collections:
+    - calaviaorg.setup
+  roles:
+    - role: gpg
+      gpg_skip_configure: false
+      gpg_key_manage: true
+      gpg_key_real_name: 'Your Name'
+      gpg_key_email: 'you@example.com'
+      gpg_key_export_public: true
+```
+
+Example with git integration (GPG signing):
+
+```yaml
+- hosts: all
+  collections:
+    - calaviaorg.setup
+  roles:
+    - role: gpg
+      gpg_key_manage: true
+      gpg_key_real_name: 'Your Name'
+      gpg_key_email: 'you@example.com'
+    - role: git
+      git_gpg_sign: true
+      git_gpg_key: 'ABC123DEF456'
+```
+
+## Platform Support
+
+- Ubuntu (focal+)
+- macOS (Darwin) — uses `brew` installer, automatically sets `gpg_privilege_escalation: false` and `pinentry-mac`
+
+## License
+
+GPL-3.0-only
+
+## Author
+
+Jorge Calavia <jorge@calavia.org>

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/defaults/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+gpg_installer: pkg
+gpg_privilege_escalation: true
+gpg_os_pkgs:
+  - gnupg
+  - pinentry-tty
+
+gpg_agent_config: '{{ ansible_env.HOME }}/.gnupg/gpg-agent.conf'
+gpg_agent_ssh_support: true
+gpg_agent_cache_ttl: 600
+gpg_agent_pinentry: ''
+
+gpg_key_manage: false
+gpg_key_type: RSA
+gpg_key_length: '4096'
+gpg_key_real_name: '{{ git_user_name | default("") }}'
+gpg_key_email: '{{ git_user_email | default("") }}'
+gpg_key_passphrase: ''
+gpg_key_import_file: ''
+gpg_key_export_public: false
+gpg_key_export_path: '{{ ansible_env.HOME }}/.gnupg/public.key'
+
+gpg_ssh_control_keys: []
+gpg_skip_configure: false

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/handlers/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: 'Reload gpg-agent'
+  ansible.builtin.command: gpgconf --reload gpg-agent
+  changed_when: false

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/meta/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: 'Jorge Calavia'
+  description: 'Role to install and manage GPG keys and agent'
+  company: 'Calavia Org'
+  license: 'GPL-3.0-only'
+  min_ansible_version: '2.19'
+  platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+  galaxy_tags:
+    - dev
+    - gpg
+    - security
+    - signing
+dependencies: []

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/brew.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/brew.yml
@@ -1,0 +1,5 @@
+---
+- name: 'Installing GPG with homebrew'
+  community.general.homebrew:
+    name: '{{ gpg_os_pkgs }}'
+    state: present

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/configure.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/configure.yml
@@ -1,0 +1,20 @@
+---
+- name: 'Ensure ~/.gnupg directory exists'
+  ansible.builtin.file:
+    path: '{{ ansible_env.HOME }}/.gnupg'
+    state: directory
+    mode: '0700'
+
+- name: 'Deploy gpg-agent.conf'
+  ansible.builtin.template:
+    src: gpg-agent.conf.j2
+    dest: '{{ gpg_agent_config }}'
+    mode: '0600'
+  notify: 'Reload gpg-agent'
+
+- name: 'Deploy sshcontrol'
+  ansible.builtin.template:
+    src: sshcontrol.j2
+    dest: '{{ ansible_env.HOME }}/.gnupg/sshcontrol'
+    mode: '0600'
+  when: gpg_agent_ssh_support and gpg_ssh_control_keys | length > 0

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/keys.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/keys.yml
@@ -1,0 +1,43 @@
+---
+- name: 'Assert required key vars'
+  ansible.builtin.assert:
+    that:
+      - gpg_key_real_name | length > 0
+      - gpg_key_email | length > 0
+    fail_msg: >-
+      gpg_key_real_name and gpg_key_email are required for key generation.
+      Set them in your playbook, or they will default to git_user_name/git_user_email.
+
+- name: 'Import GPG key from file'
+  ansible.builtin.command: >
+    gpg --batch --import {{ gpg_key_import_file }}
+  changed_when: false
+  when: gpg_key_import_file | length > 0
+
+- name: 'Generate GPG key (batch mode)'
+  ansible.builtin.shell: |
+    cat > /tmp/gpg-key-batch <<'BATCH_EOF'
+    Key-Type: {{ gpg_key_type }}
+    Key-Length: {{ gpg_key_length }}
+    Key-Usage: sign,auth
+    Subkey-Type: {{ gpg_key_type }}
+    Subkey-Length: {{ gpg_key_length }}
+    Subkey-Usage: encrypt,sign,auth
+    Name-Real: {{ gpg_key_real_name }}
+    Name-Email: {{ gpg_key_email }}
+    Expire-Date: 0
+    %no-protection
+    %transient-key
+    %commit
+    BATCH_EOF
+    gpg --batch --generate-key /tmp/gpg-key-batch
+  args:
+    creates: '{{ ansible_env.HOME }}/.gnupg/openpgp-revocs.d/'
+  when: gpg_key_import_file | length == 0
+
+- name: 'Export public key'
+  ansible.builtin.shell: >
+    gpg --armor --export {{ gpg_key_email }} > {{ gpg_key_export_path }}
+  args:
+    creates: '{{ gpg_key_export_path }}'
+  when: gpg_key_export_public

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: 'Resolve platform specific vars'
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml'
+        - '{{ ansible_distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
+      skip: true
+      paths:
+        - '{{ role_path }}/vars'
+
+- name: 'Install GPG'
+  ansible.builtin.include_tasks: '{{ gpg_installer }}.yml'
+
+- name: 'Configure GPG agent'
+  ansible.builtin.include_tasks: configure.yml
+  when: not gpg_skip_configure | bool
+
+- name: 'Manage GPG keys'
+  ansible.builtin.include_tasks: keys.yml
+  when: gpg_key_manage

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/pkg.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/tasks/pkg.yml
@@ -1,0 +1,15 @@
+---
+- name: 'Update apt cache...'
+  when: ansible_pkg_mgr == 'apt'
+  become: '{{ gpg_privilege_escalation }}'
+  become_user: root
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: 'Install GPG os pkgs...'
+  become: '{{ gpg_privilege_escalation }}'
+  become_user: root
+  ansible.builtin.package:
+    name: '{{ gpg_os_pkgs }}'
+    state: present

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/templates/gpg-agent.conf.j2
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/templates/gpg-agent.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+# GPG agent configuration managed by Ansible
+
+default-cache-ttl {{ gpg_agent_cache_ttl }}
+max-cache-ttl {{ gpg_agent_cache_ttl * 2 }}
+{% if gpg_agent_pinentry | length > 0 %}
+pinentry-program {{ gpg_agent_pinentry }}
+{% endif %}
+{% if gpg_agent_ssh_support %}
+enable-ssh-support
+{% endif %}

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/templates/sshcontrol.j2
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/templates/sshcontrol.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+{% for keygrip in gpg_ssh_control_keys %}
+{{ keygrip }}
+{% endfor %}

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/vars/Darwin.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/vars/Darwin.yml
@@ -1,0 +1,6 @@
+---
+gpg_privilege_escalation: false
+gpg_os_pkgs:
+  - gnupg
+  - pinentry-mac
+gpg_agent_pinentry: /opt/homebrew/bin/pinentry-mac

--- a/collections/ansible_collections/calaviaorg/setup/roles/gpg/vars/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/gpg/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for gpg

--- a/extensions/molecule/gpg/converge.yml
+++ b/extensions/molecule/gpg/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  collections:
+    - calaviaorg.setup
+  tasks:
+    - name: "Include setup"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/extensions/molecule/gpg/molecule.yml
+++ b/extensions/molecule/gpg/molecule.yml
@@ -1,0 +1,26 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-ubuntu2204-ansible:latest"
+    pre_build_image: true
+provisioner:
+  name: ansible
+  env:
+    MOLECULE_PROJECT_DIRECTORY: "extensions/molecule/gpg"
+  config_options:
+    defaults:
+      interpreter_python: auto_silent
+  inventory:
+    group_vars:
+      all:
+        gpg_skip_configure: false
+        gpg_key_manage: true
+        gpg_key_real_name: 'Molecule Test'
+        gpg_key_email: 'molecule@gpg.test'
+        gpg_key_export_public: true
+verifier:
+  name: ansible

--- a/extensions/molecule/gpg/verify.yml
+++ b/extensions/molecule/gpg/verify.yml
@@ -1,0 +1,62 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: 'TEST: gpg binary exists'
+      ansible.builtin.command: which gpg
+      changed_when: false
+      register: gpg_bin
+
+    - name: 'Assert gpg is installed'
+      ansible.builtin.assert:
+        that: gpg_bin.rc == 0
+
+    - name: 'TEST: gpg version'
+      ansible.builtin.command: gpg --version
+      changed_when: false
+      register: gpg_ver
+
+    - name: 'Assert gpg version non-empty'
+      ansible.builtin.assert:
+        that: gpg_ver.stdout | length > 0
+
+    - name: 'TEST: gpg-agent config exists'
+      ansible.builtin.stat:
+        path: '{{ ansible_env.HOME }}/.gnupg/gpg-agent.conf'
+      register: gpg_agent_cfg
+
+    - name: 'Assert gpg-agent config deployed'
+      ansible.builtin.assert:
+        that: gpg_agent_cfg.stat.exists
+
+    - name: 'TEST: gpg secret key exists for Molecule Test'
+      ansible.builtin.command: >
+        gpg --list-secret-keys --keyid-format LONG molecule@gpg.test
+      changed_when: false
+      register: gpg_key_list
+      failed_when: false
+
+    - name: 'Assert secret key exists'
+      ansible.builtin.assert:
+        that: gpg_key_list.rc == 0
+        msg: 'GPG secret key for molecule@gpg.test not found'
+
+    - name: 'TEST: public key exported'
+      ansible.builtin.stat:
+        path: '{{ ansible_env.HOME }}/.gnupg/public.key'
+      register: gpg_pub_key
+
+    - name: 'Assert public key exported'
+      ansible.builtin.assert:
+        that: gpg_pub_key.stat.exists
+
+    - name: 'TEST: public key contains test email'
+      ansible.builtin.command: >
+        gpg --list-keys --keyid-format LONG molecule@gpg.test
+      changed_when: false
+      register: gpg_pub_list
+
+    - name: 'Assert public key has correct user'
+      ansible.builtin.assert:
+        that: gpg_pub_list.stdout is search('Molecule Test')

--- a/molecule
+++ b/molecule
@@ -1,0 +1,1 @@
+extensions/molecule


### PR DESCRIPTION
Adds a new `calaviaorg.setup.gpg` role for managing GPG installation, key generation/import, agent configuration, and SSH integration.

**Role features:**
- Install gnupg/pinentry via apt or brew
- Configure gpg-agent (cache TTL, pinentry-program, SSH support)
- Generate or import GPG keys (batch mode)
- Export public keys
- Manage SSH keygrips via sshcontrol

**Git integration:**
- Git role now depends on GPG (soft dependency: install only, no config)
- User enables signing via `git_gpg_sign: true` + `git_gpg_key`
- GPG role provides the underlying keys and agent

**Tests:**
- ✅ GPG molecule test: 1 passed (install + configure + key generation + export)
- ✅ Git molecule test: 1 passed (with GPG dependency)
- ✅ Unit tests: 2 passed