### PR TITLE
feat: add opencode.nvim plugin to nvim role

### DIFF
--- a/collections/ansible_collections/calaviaorg/setup/playbooks/full_macos_setup.yml
+++ b/collections/ansible_collections/calaviaorg/setup/playbooks/full_macos_setup.yml
@@ -1,0 +1,41 @@
+---
+- name: 'Full macOS development machine setup'
+  hosts: localhost
+  connection: local
+  collections:
+    - calaviaorg.setup
+  vars:
+    # Git identity (used by gpg key generation too)
+    git_user_name: '{{ lookup("env", "USER") }}'
+    git_user_email: '{{ lookup("env", "USER") }}@{{ ansible_hostname }}'
+
+    # GPG key generation
+    gpg_key_manage: true
+    gpg_key_real_name: '{{ git_user_name }}'
+    gpg_key_email: '{{ git_user_email }}'
+    gpg_key_export_public: true
+
+    # Enable all opencode plugins
+    opencode_engram_enable: true
+    opencode_opentmux_enable: true
+
+    # Enable all mise tools
+    mise_python_enable: true
+    mise_java_enable: true
+    mise_node_enable: true
+    mise_go_enable: true
+
+  roles:
+    - role: git
+      git_gpg_sign: true
+
+    - role: gpg
+
+    - role: tmux
+      tmux_tpm_enable: true
+
+    - role: nvim
+
+    - role: opencode
+
+    - role: mise

--- a/collections/ansible_collections/calaviaorg/setup/roles/nvim/README.md
+++ b/collections/ansible_collections/calaviaorg/setup/roles/nvim/README.md
@@ -50,6 +50,7 @@ and configurable treesitter languages.
 | `nvim_plugin_lualine` | `true` | lualine.nvim statusline |
 | `nvim_plugin_which_key` | `true` | which-key.nvim key hints |
 | `nvim_plugin_neotree` | `true` | neo-tree.nvim file explorer |
+| `nvim_plugin_opencode` | `false` | opencode.nvim OpenCode AI integration |
 
 ### LSP Servers
 
@@ -95,6 +96,7 @@ nvim_treesitter_languages:
 ## Dependencies
 
 - [git](../git/README.md) — required for lazy.nvim bootstrap
+- [opencode](../opencode/README.md) — required when `nvim_plugin_opencode` is enabled
 
 ## Example Playbook
 

--- a/collections/ansible_collections/calaviaorg/setup/roles/nvim/defaults/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/nvim/defaults/main.yml
@@ -25,6 +25,7 @@ nvim_plugin_tokyonight: true
 nvim_plugin_lualine: true
 nvim_plugin_which_key: true
 nvim_plugin_neotree: true
+nvim_plugin_opencode: false
 
 nvim_lsp_servers:
   - lua_ls

--- a/collections/ansible_collections/calaviaorg/setup/roles/nvim/meta/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/nvim/meta/main.yml
@@ -17,3 +17,4 @@ galaxy_info:
 dependencies:
   - role: git
     git_skip_configure: true
+  - role: opencode

--- a/collections/ansible_collections/calaviaorg/setup/roles/nvim/tasks/configure.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/nvim/tasks/configure.yml
@@ -35,6 +35,7 @@
     - { file: lsp.lua, toggle: nvim_plugin_lsp }
     - { file: tools.lua, toggle: nvim_plugin_tools }
     - { file: ui.lua, toggle: nvim_plugin_ui }
+    - { file: opencode.lua, toggle: nvim_plugin_opencode }
   when: vars[item.toggle]
 
 - name: 'Deploy lazy-lock.json'

--- a/collections/ansible_collections/calaviaorg/setup/roles/nvim/templates/lua/plugins/opencode.lua.j2
+++ b/collections/ansible_collections/calaviaorg/setup/roles/nvim/templates/lua/plugins/opencode.lua.j2
@@ -1,0 +1,48 @@
+-- {{ ansible_managed }}
+-- opencode.nvim plugin managed by Ansible
+
+return {
+{% if nvim_plugin_opencode %}
+  {
+    "nickjvandyke/opencode.nvim",
+    version = "*",
+    dependencies = {
+      {
+        "folke/snacks.nvim",
+        optional = true,
+        opts = {
+          input = {},
+          picker = {
+            actions = {
+              opencode_send = function(...)
+                return require("opencode").snacks_picker_send(...)
+              end,
+            },
+          },
+        },
+      },
+    },
+    config = function()
+      vim.g.opencode_opts = {
+        events = {
+          enabled = true,
+          reload = true,
+        },
+      }
+      vim.o.autoread = true
+
+      vim.keymap.set({ "n", "x" }, "<C-a>", function()
+        require("opencode").ask("@this: ", { submit = true })
+      end, { desc = "Ask opencode…" })
+
+      vim.keymap.set({ "n", "x" }, "<C-x>", function()
+        require("opencode").select()
+      end, { desc = "Select opencode…" })
+
+      vim.keymap.set({ "n", "t" }, "<C-.>", function()
+        require("opencode").toggle()
+      end, { desc = "Toggle opencode" })
+    end,
+  },
+{% endif %}
+}


### PR DESCRIPTION
Adds opencode.nvim integration to the nvim role:

- New toggle variable: `nvim_plugin_opencode` (default: false)
- New template: `lua/plugins/opencode.lua.j2` with the plugin spec and keymaps
- nvim role now depends on opencode role (like opencode depends on tmux)
- Updated README with new variable documentation
- Also includes the full_macos_setup playbook