### PR TITLE
fix: replace community.general.homebrew in engram.yml

### DIFF
--- a/collections/ansible_collections/calaviaorg/setup/roles/opencode/tasks/engram.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/opencode/tasks/engram.yml
@@ -1,8 +1,8 @@
 ---
 - name: 'Install Engram via Homebrew'
-  community.general.homebrew:
-    name: gentleman-programming/tap/engram
-    state: present
+  ansible.builtin.command:
+    cmd: 'brew install gentleman-programming/tap/engram'
+  changed_when: false
   when: ansible_os_family == 'Darwin'
 
 - name: 'Install Engram via Go'


### PR DESCRIPTION
Replaces the community.general.homebrew module with ansible.builtin.command to avoid CI failures where the community.general collection is not installed.