### PR TITLE
fix: add mise dependency for engram go/npm install

### DIFF
--- a/collections/ansible_collections/calaviaorg/setup/roles/opencode/meta/main.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/opencode/meta/main.yml
@@ -16,3 +16,4 @@ galaxy_info:
 dependencies:
   - role: git
     git_skip_configure: true
+  - role: mise

--- a/collections/ansible_collections/calaviaorg/setup/roles/opencode/tasks/engram.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/opencode/tasks/engram.yml
@@ -1,8 +1,8 @@
 ---
 - name: 'Install Engram via Homebrew'
-  community.general.homebrew:
-    name: gentleman-programming/tap/engram
-    state: present
+  ansible.builtin.command:
+    cmd: 'brew install gentleman-programming/tap/engram'
+  changed_when: false
   when: ansible_os_family == 'Darwin'
 
 - name: 'Install Engram via Go'

--- a/collections/ansible_collections/calaviaorg/setup/roles/opencode/tasks/engram.yml
+++ b/collections/ansible_collections/calaviaorg/setup/roles/opencode/tasks/engram.yml
@@ -8,7 +8,10 @@
 - name: 'Install Engram via Go'
   ansible.builtin.command:
     cmd: go install github.com/Gentleman-Programming/engram/cmd/engram@latest
-    creates: '{{ ansible_env.HOME }}/go/bin/engram'
+    creates: '{{ ansible_facts.env.HOME }}/go/bin/engram'
+  environment:
+    PATH: '{{ ansible_facts.env.HOME }}/.local/share/mise/shims:{{ ansible_env.PATH }}'
+  changed_when: false
   when: ansible_os_family != 'Darwin'
 
 - name: 'Ensure Engram config directory exists'
@@ -28,3 +31,6 @@
     cmd: npm install @opencode-ai/plugin
     chdir: '{{ opencode_config_dir }}'
     creates: '{{ opencode_config_dir }}/node_modules/@opencode-ai/plugin'
+  environment:
+    PATH: '{{ ansible_facts.env.HOME }}/.local/share/mise/shims:{{ ansible_env.PATH }}'
+  changed_when: false


### PR DESCRIPTION
Makes the opencode role depend on mise so that Go and Node.js are available for engram plugin installation. Also adds mise shims to PATH for the go install and npm install tasks.