### PR TITLE
fix: allow bash in tox commands_pre to fix release workflow

### DIFF
--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -10,6 +10,8 @@ skip =
     py3.14
 
 [testenv]
+allowlist_externals =
+    bash
 passenv =
     MOLECULE_PROJECT_DIRECTORY
 setenv =


### PR DESCRIPTION
## What
Add `allowlist_externals = bash` to `[testenv]` in `tox-ansible.ini`.

## Why
Tox 4+ blocks raw `bash` calls in `commands_pre` unless explicitly allowed. The release workflow's test jobs all fail with:

```
sanity: failed with bash is not allowed, use allowlist_externals to allow it
```

This happens because the release workflow uses generic environments (`-e sanity`, `-e unit`, `-e integration`) which auto-resolve via tox-ansible, and these resolved environments enforce tox 4's strict external command policy.

The PR workflow didn't hit this because it uses explicit environment names (`integration-py3.12-2.20`) with an older tox version path.

## Testing
- Pre-commit passes
- Will verify release workflow tests pass after merge