### PR TITLE
fix: release workflow test execution and protected branch commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e sanity
+          -e sanity-py3.12-2.19
           --conf tox-ansible.ini
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e unit
+          -e unit-py3.12-2.19
           --conf tox-ansible.ini
           --
           --show-capture=all
@@ -102,7 +102,7 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e integration
+          -e integration-py3.12-2.19
           --conf tox-ansible.ini
           --
           --show-capture=all
@@ -146,43 +146,28 @@ jobs:
           sed -i "s/^version: .*/version: ${{ steps.version.outputs.version }}/" collections/ansible_collections/calaviaorg/setup/galaxy.yml
           grep "^version:" collections/ansible_collections/calaviaorg/setup/galaxy.yml
 
-      - name: Generate CHANGELOG
+      - name: Generate release notes
+        id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
 
-          if [ -f CHANGELOG.md ]; then
-            echo "# Changelog" > CHANGELOG.md.new
-          else
-            echo "# Changelog" > CHANGELOG.md.new
-            echo "" >> CHANGELOG.md.new
-          fi
+          {
+            echo "# Changelog"
+            echo ""
+            echo "## [$VERSION] - $(date +%Y-%m-%d)"
+            echo ""
 
-          echo "## [$VERSION] - $(date +%Y-%m-%d)" >> CHANGELOG.md.new
-          echo "" >> CHANGELOG.md.new
+            if [ -n "$PREVIOUS_TAG" ]; then
+              git log "$PREVIOUS_TAG..HEAD" --pretty=format:"- %s (%h)" --no-merges
+            else
+              git log --pretty=format:"- %s (%h)" --no-merges
+            fi
 
-          if [ -n "$PREVIOUS_TAG" ]; then
-            git log "$PREVIOUS_TAG..HEAD" --pretty=format:"- %s (%h)" --no-merges >> CHANGELOG.md.new
-          else
-            git log --pretty=format:"- %s (%h)" --no-merges >> CHANGELOG.md.new
-          fi
+            echo ""
+          } > RELEASE_NOTES.md
 
-          echo "" >> CHANGELOG.md.new
-
-          if [ -f CHANGELOG.md ]; then
-            tail -n +2 CHANGELOG.md >> CHANGELOG.md.new
-          fi
-
-          mv CHANGELOG.md.new CHANGELOG.md
-          cat CHANGELOG.md | head -30
-
-      - name: Commit version and CHANGELOG
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git add collections/ansible_collections/calaviaorg/setup/galaxy.yml CHANGELOG.md
-          git diff --cached --quiet || git commit -m "chore: release v${{ steps.version.outputs.version }}"
-          git push origin HEAD:main
+          cat RELEASE_NOTES.md | head -30
 
       - name: Build collection
         run: |
@@ -195,10 +180,10 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Release v${{ steps.version.outputs.version }}
-          body_path: CHANGELOG.md
+          body_path: RELEASE_NOTES.md
           files: |
             collections/ansible_collections/calaviaorg/setup/calaviaorg-setup-*.tar.gz
-          generate_release_notes: true
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Issues Fixed

### 1. Tests not executing
The release workflow used generic tox environment names like `-e unit`, but tox-ansible generates specific environments like `unit-py3.12-2.19`. The generic names had no `commands` defined, so only `commands_pre` ran and tests were silently skipped.

**Fix:** Changed to explicit environment names:
- `-e sanity-py3.12-2.19`
- `-e unit-py3.12-2.19`
- `-e integration-py3.12-2.19`

### 2. Protected branch push rejected
The `Commit version and CHANGELOG` step tried to push directly to `main`, failing with:
```
GH006: Protected branch update failed for refs/heads/main
Changes must be made through a pull request
```

**Fix:** Removed the commit/push step entirely. The workflow now:
- Updates `galaxy.yml` in the working tree (for the build)
- Generates `RELEASE_NOTES.md` as a workflow artifact (not committed to repo)
- Creates GitHub Release using the generated notes
- Builds and publishes collection without modifying main

### 3. Workflow triggering
The workflow was triggering correctly on tags, but failing before reaching the release step. With the above fixes, it will now complete end-to-end.

## Notes
- `generate_release_notes` disabled in `action-gh-release` since we provide our own `body_path`
- The release notes are generated from git log between the current tag and previous tag
- `galaxy.yml` version is updated for the build artifact but not committed to main