### PR TITLE
fix: use milestone instead of 2.19 for tox envs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e sanity-py3.12-2.19
+          -e sanity-py3.12-milestone
           --conf tox-ansible.ini
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e unit-py3.12-2.19
+          -e unit-py3.12-milestone
           --conf tox-ansible.ini
           --
           --show-capture=all
@@ -102,7 +102,7 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e integration-py3.12-2.19
+          -e integration-py3.12-milestone
           --conf tox-ansible.ini
           --
           --show-capture=all


### PR DESCRIPTION
## Problem
The release workflow was using explicit tox environment names with `2.19` (e.g., `sanity-py3.12-2.19`), but 2.19 is listed in the `skip` section of `tox-ansible.ini`. While the environment still exists when explicitly requested, it may be unstable or outdated.

Additionally, sanity tests were failing because tox-ansible auto-generates commands that cd into the tox virtualenv's site-packages path, but our `commands_pre` installs the collection to `{env_tmp_dir}/collections` instead.

## Solution
1. Changed all three test environments to use `milestone` which is the current active version shown by the tox-ansible matrix:
   - `sanity-py3.12-milestone`
   - `unit-py3.12-milestone`  
   - `integration-py3.12-milestone`

2. Added `[testenv:sanity-py3.12-milestone]` override in `tox-ansible.ini` with explicit `commands` that use our collection install path, bypassing tox-ansible's auto-generated site-packages path.

## Changes
- 3 lines changed in `.github/workflows/release.yml` (2.19 → milestone)
- 4 lines added to `tox-ansible.ini` (sanity environment command override)