### PR TITLE
fix: override sanity test commands to use correct collection path

### DIFF
--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -20,3 +20,7 @@ commands_pre =
     bash -c 'mkdir -p {env_tmp_dir}/collection_build && cd {toxinidir} && git archive HEAD | tar xf - -C {env_tmp_dir}/collection_build'
     bash -c 'cd {env_tmp_dir}/collection_build/collections/ansible_collections/calaviaorg/setup && ansible-galaxy collection build && ansible-galaxy collection install --force calaviaorg-setup-*.tar.gz -p {env_tmp_dir}/collections'
     bash -c 'cd {env_tmp_dir}/collections/ansible_collections/calaviaorg/setup && git init .'
+
+[testenv:sanity-py3.12-milestone]
+commands =
+    bash -c 'cd {env_tmp_dir}/collections/ansible_collections/calaviaorg/setup && ansible-test sanity --local --requirements --python 3.12'


### PR DESCRIPTION
## Problem
tox-ansible auto-generates commands that cd into the tox virtualenv's site-packages path:
```
{envdir}/lib/python3.12/site-packages/ansible_collections/calaviaorg/setup
```

But our `commands_pre` installs the collection to:
```
{env_tmp_dir}/collections/ansible_collections/calaviaorg/setup
```

These paths don't match, causing sanity tests to fail with:
```
No such file or directory
```

## Solution
Added `[testenv:sanity-py3.12-milestone]` section to `tox-ansible.ini` with explicit `commands` that use our install path, bypassing tox-ansible's auto-generated path.

## Changes
- 4 lines added to `tox-ansible.ini`
- Sanity tests now use: `cd {env_tmp_dir}/collections/ansible_collections/calaviaorg/setup && ansible-test sanity ...`