### PR TITLE
fix: use milestone instead of 2.19 for Darwin molecule tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -199,11 +199,11 @@ jobs:
         run: >-
           python3 -m tox
           --ansible
-          -e integration-py3.12-2.19
+          -e integration-py3.12-milestone
           --conf tox-ansible.ini
           --
           --show-capture=all
-          --junit-xml=test/reports/integration-darwin-py3.12-2.19.xml
+          --junit-xml=test/reports/integration-darwin-py3.12-milestone.xml
           -k darwin
 
   test_passed:


### PR DESCRIPTION
Fixes the Darwin molecule tests failing because the tox environment 

tegration-py3.12-2.19
does not exist (2.19 is skipped in tox-ansible.ini).

## Changes
- Update Darwin molecule job to use 

  egration-py3.12-milestone
  nstead of 

  egration-py3.12-2.19
- Update junit output filename accordingly

This matches the release workflow fix from PR #57.