### PR TITLE
fix: restructure release workflow to fix EE build and auto-trigger

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -1,0 +1,105 @@
+name: Auto-bump Version
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  bump-version:
+    if: github.event.pull_request.head.repo.full_name == github.repository && (startsWith(github.head_ref, 'major/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'fix/'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract branch type
+        id: branch
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if [[ "$BRANCH" == major/* ]]; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif [[ "$BRANCH" == feat/* ]]; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          elif [[ "$BRANCH" == fix/* ]]; then
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read current version
+        id: current
+        run: |
+          VERSION=$(grep "^version:" collections/ansible_collections/jcalavia_org/setup/galaxy.yml | sed 's/version: //')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
+
+      - name: Bump version
+        id: bump
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          TYPE="${{ steps.branch.outputs.type }}"
+
+          # Parse semver
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+
+          case "$TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT -> $NEW_VERSION ($TYPE)"
+
+      - name: Update galaxy.yml
+        run: |
+          sed -i "s/^version: .*/version: ${{ steps.bump.outputs.new_version }}/" collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+
+      - name: Check if changes exist
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to commit"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version bump detected"
+          fi
+
+      - name: Check if last commit was already a version bump
+        id: last_commit
+        run: |
+          LAST_COMMIT=$(git log -1 --pretty=%B)
+          if echo "$LAST_COMMIT" | grep -q "chore: bump version"; then
+            echo "already_bumped=true" >> "$GITHUB_OUTPUT"
+            echo "Last commit was already a version bump, skipping"
+          else
+            echo "already_bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push version bump
+        if: steps.check.outputs.changed == 'true' && steps.last_commit.outputs.already_bumped == 'false'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} (${{ steps.branch.outputs.type }})"
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,16 @@ on:
         required: true
         type: string
   push:
+    branches:
+      - main
+    paths:
+      - 'collections/ansible_collections/jcalavia_org/setup/galaxy.yml'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   sanity:
@@ -110,8 +115,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  release:
-    name: Build and Release
+  build:
+    name: Build and Publish
     needs: [sanity, unit_test, integration_test]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -128,30 +133,138 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
-          else
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "tag" ]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            # Push to main - extract from galaxy.yml
+            VERSION=$(grep "^version:" collections/ansible_collections/jcalavia_org/setup/galaxy.yml | sed 's/version: //')
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists. Skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Python
+        if: steps.check_tag.outputs.skip == 'false'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        if: steps.check_tag.outputs.skip == 'false'
+        run: |
+          python3 -m pip install ansible tox-ansible
+
+      - name: Update galaxy.yml version
+        if: steps.check_tag.outputs.skip == 'false'
+        run: |
+          sed -i "s/^version: .*/version: ${{ steps.version.outputs.version }}/" collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+          grep "^version:" collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+
+      - name: Build collection
+        if: steps.check_tag.outputs.skip == 'false'
+        run: |
+          cd collections/ansible_collections/jcalavia_org/setup
+          ansible-galaxy collection build --force
+          ls -la *.tar.gz
+
+      - name: Upload collection artifact
+        if: steps.check_tag.outputs.skip == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: collection-artifact
+          path: collections/ansible_collections/jcalavia_org/setup/jcalavia_org-setup-*.tar.gz
+          retention-days: 1
+
+      - name: Publish to Ansible Galaxy
+        if: steps.check_tag.outputs.skip == 'false'
+        run: |
+          cd collections/ansible_collections/jcalavia_org/setup
+          ansible-galaxy collection publish jcalavia_org-setup-*.tar.gz --api-key="${{ secrets.ANSIBLE_GALAXY_API_KEY }}"
+        env:
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+
+  build-ee:
+    name: Build Execution Environment
+    needs: build
+    if: needs.build.outputs.version != '' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install ansible tox-ansible
+      - name: Download collection artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: collection-artifact
+          path: collections/ansible_collections/jcalavia_org/setup/
 
-      - name: Update galaxy.yml version
+      - name: Create EE context directories
         run: |
-          sed -i "s/^version: .*/version: ${{ steps.version.outputs.version }}/" collections/ansible_collections/jcalavia_org/setup/galaxy.yml
-          grep "^version:" collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+          mkdir -p context/_build
+
+      - name: Copy collection to EE context
+        run: |
+          cp collections/ansible_collections/jcalavia_org/setup/jcalavia_org-setup-*.tar.gz context/_build/
+          echo "  - name: jcalavia_org-setup-${{ needs.build.outputs.version }}.tar.gz" >> context/_build/requirements.yml
+
+      - name: Build execution environment
+        run: |
+          docker build \
+            -f context/Containerfile \
+            -t ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.build.outputs.version }} \
+            -t ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest \
+            context/
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push execution environment image
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.build.outputs.version }}
+          docker push ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build, build-ee]
+    if: needs.build.outputs.version != '' && needs.build.result == 'success' && needs.build-ee.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download collection artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: collection-artifact
+          path: artifacts/
 
       - name: Generate release notes
         id: changelog
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.build.outputs.version }}"
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
 
           {
@@ -171,83 +284,14 @@ jobs:
 
           cat RELEASE_NOTES.md | head -30
 
-      - name: Build collection
-        run: |
-          cd collections/ansible_collections/jcalavia_org/setup
-          ansible-galaxy collection build --force
-          ls -la *.tar.gz
-
-      - name: Upload collection artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: collection-artifact
-          path: collections/ansible_collections/jcalavia_org/setup/jcalavia_org-setup-*.tar.gz
-          retention-days: 1
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: Release v${{ steps.version.outputs.version }}
+          tag_name: v${{ needs.build.outputs.version }}
+          name: Release v${{ needs.build.outputs.version }}
           body_path: RELEASE_NOTES.md
           files: |
-            collections/ansible_collections/jcalavia_org/setup/jcalavia_org-setup-*.tar.gz
+            artifacts/jcalavia_org-setup-*.tar.gz
           generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to Ansible Galaxy
-        run: |
-          cd collections/ansible_collections/jcalavia_org/setup
-          ansible-galaxy collection publish jcalavia_org-setup-*.tar.gz --api-key="${{ secrets.ANSIBLE_GALAXY_API_KEY }}"
-        env:
-          ANSIBLE_GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
-
-  build-ee:
-    name: Build Execution Environment
-    needs: release
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Download collection artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: collection-artifact
-          path: collections/ansible_collections/jcalavia_org/setup/
-
-      - name: Copy collection to EE context
-        run: |
-          cp collections/ansible_collections/jcalavia_org/setup/jcalavia_org-setup-*.tar.gz context/_build/
-          echo "  - name: jcalavia_org-setup-${{ needs.release.outputs.version }}.tar.gz" >> context/_build/requirements.yml
-
-      - name: Build execution environment
-        run: |
-          docker build \
-            -f context/Containerfile \
-            -t ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.release.outputs.version }} \
-            -t ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest \
-            context/
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push execution environment image
-        run: |
-          docker push ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.release.outputs.version }}
-          docker push ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest

--- a/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+++ b/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: jcalavia_org
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.1
+version: 1.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+++ b/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: jcalavia_org
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+++ b/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: jcalavia_org
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.2
+version: 1.1.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Fixes three issues with the release workflow:

## 1. Execution Environment build fails
The  directory doesn't exist when the workflow tries to copy the collection artifact. Added  before the copy step.

## 2. GitHub Release published before Galaxy publish
Previously, the GitHub release was created in the same job as the build, before Galaxy publish and EE build. If those steps failed, the release was already out with a broken artifact.

**New structure:**
- **build** job: Build collection, upload artifact, publish to Galaxy
- **build-ee** job: Build and push execution environment (depends on build)
- **create-release** job: Create GitHub release (depends on both, LAST step)

## 3. Auto-trigger on PR merge
The workflow now triggers automatically when  is changed on a push to . The version is extracted from  and the release proceeds. If the tag already exists, the release is skipped to avoid duplicates.

**Triggers:**
- Manual dispatch (workflow_dispatch)
- Push to main when galaxy.yml changes
- Push of version tag (v*.*.*)
