### PR TITLE
fix: resolve auto-bump version collision and EE build failure

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -32,12 +32,19 @@ jobs:
             echo "type=patch" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Read current version
+      - name: Fetch main and get latest tag
+        run: |
+          git fetch origin main --tags
+
+      - name: Read latest tag version
         id: current
         run: |
-          VERSION=$(grep "^version:" collections/ansible_collections/jcalavia_org/setup/galaxy.yml | sed 's/version: //')
+          # Get the latest tag from main (e.g., v1.1.2 -> 1.1.2)
+          LATEST_TAG=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "0.0.0")
+          # Remove the 'v' prefix if present
+          VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Current version: $VERSION"
+          echo "Latest tag on main: $LATEST_TAG → base version: $VERSION"
 
       - name: Bump version
         id: bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,28 +208,23 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install ansible-builder and docker
+        run: |
+          python3 -m pip install ansible-builder
+
       - name: Download collection artifact
         uses: actions/download-artifact@v4
         with:
           name: collection-artifact
           path: collections/ansible_collections/jcalavia_org/setup/
 
-      - name: Create EE context directories
-        run: |
-          mkdir -p context/_build
-
-      - name: Copy collection to EE context
-        run: |
-          cp collections/ansible_collections/jcalavia_org/setup/jcalavia_org-setup-*.tar.gz context/_build/
-          echo "  - name: jcalavia_org-setup-${{ needs.build.outputs.version }}.tar.gz" >> context/_build/requirements.yml
-
       - name: Build execution environment
         run: |
-          docker build \
-            -f context/Containerfile \
-            -t ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.build.outputs.version }} \
-            -t ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest \
-            context/
+          ansible-builder build \
+            --file execution-environment.yml \
+            --context ./context \
+            --tag ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.build.outputs.version }} \
+            --tag ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
+++ b/collections/ansible_collections/jcalavia_org/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: jcalavia_org
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.3
+version: 1.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Fixes two critical CI issues:

## 1. Auto-bump version collision
When multiple branches are in development, they all start from the same
galaxy.yml version and bump to the same new version. Now the auto-bump
workflow fetches the latest tag from main and uses that as the base:

- Runs 'git fetch origin main --tags'
- Gets latest tag: 'git describe --tags --abbrev=0 origin/main'
- Strips 'v' prefix and bumps from there

This ensures parallel branches get unique versions.

## 2. Execution Environment build fails
The context/Containerfile was deleted during the merge. Instead of trying
to recreate it manually, use ansible-builder which generates the context
from execution-environment.yml:

- Install ansible-builder in the build-ee job
- Run 'ansible-builder build --file execution-environment.yml --context ./context'
- Tags the image and pushes to ghcr.io

This is the proper way to build Ansible Execution Environments.