### PR TITLE
fix: add python3 symlink for EE base image

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -13,5 +13,6 @@ dependencies:
 
 additional_build_steps:
   prepend_base:
+    - RUN ln -s /usr/local/bin/python3.12 /usr/bin/python3 || true
     - RUN pip3 install --upgrade pip setuptools
     - RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes the Execution Environment build failure caused by the python:3.12-slim base image not having python3 at /usr/bin/python3.

## Error


## Fix
Add a symlink in the execution-environment.yml prepend_base step:


The python:3.12-slim base image has python3.12 at /usr/local/bin/python3.12 but ansible-builder scripts expect /usr/bin/python3.