### PR TITLE
fix: use docker runtime for ansible-builder to enable GHCR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,7 @@ jobs:
           ansible-builder build \
             --file execution-environment.yml \
             --context ./context \
+            --container-runtime docker \
             --tag ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:${{ needs.build.outputs.version }} \
             --tag ghcr.io/${{ github.repository_owner }}/ansible-ee-setup:latest
 


### PR DESCRIPTION
## Problem

The <code>build-ee</code> job in the release workflow was failing during the image push step to GHCR.

<code>ansible-builder</code> defaults to <strong>podman</strong> when available on Ubuntu runners, but the push step uses <strong>docker</strong>. Since podman and docker maintain separate image stores, <code>docker push</code> fails because it cannot find the image that podman built.

## Solution

Add <code>--container-runtime docker</code> to the <code>ansible-builder build</code> command, ensuring both build and push use the same container engine.

## Why keep GHCR?

- Already configured with correct permissions (<code>packages: write</code>)
- Free for public repositories
- Uses <code>GITHUB_TOKEN</code> — no extra secrets needed
- Native GitHub integration

## Changes

- <code>.github/workflows/release.yml</code>: Added <code>--container-runtime docker</code> flag