### PR TITLE
docs: restructure README and enhance release and playbook documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,30 @@
-# Ansible Collection - jcalavia_org.setup
+# Ansible Collection — jcalavia_org.setup
 
 [![codecov](https://codecov.io/gh/calavia-org/ansible-collection-setup/branch/main/graph/badge.svg?token=T5NUI2U885)](https://codecov.io/gh/calavia-org/ansible-collection-setup)
 [![PR Checks](https://github.com/calavia-org/ansible-collection-setup/actions/workflows/pr-check-and-bump.yml/badge.svg)](https://github.com/calavia-org/ansible-collection-setup/actions/workflows/pr-check-and-bump.yml)
 
-This Ansible collection sets up the local development environment:
+An Ansible collection for setting up local development environments (git, tmux, GPG, Neovim, OpenCode, mise). Published to Ansible Galaxy as `jcalavia_org.setup`.
 
-* git
-* vim
-* tmux
+## Docs
 
-## Supported platforms
+| Topic | Location |
+|-------|----------|
+| Collection (roles, installation, usage) | [`collections/.../setup/README.md`](collections/ansible_collections/jcalavia_org/setup/README.md) |
+| Playbooks (variables, examples) | [`collections/.../setup/playbooks/README.md`](collections/ansible_collections/jcalavia_org/setup/playbooks/README.md) |
+| Release process | [`RELEASE.md`](RELEASE.md) |
+| Contributing | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 
-* macOS
-* Ubuntu / Debian
+## Quick Start
 
-## Development
+```bash
+git clone https://github.com/calavia-org/ansible-collection-setup.git
+cd ansible-collection-setup
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+tox -e unit-py3.12-2.17 --ansible --conf tox-ansible.ini
+```
 
-### Useful commands
+## Supported Platforms
 
-* `tox -e unit-py3.12-2.17 --ansible --conf tox-ansible.ini -- junit-xml=tests/reports/unit.xml`
-* `tox -e integration-py3.12-2.17 --ansible --conf tox-ansible.ini -- junit-xml=tests/reports/integration.xml`
-
-## Pull Request Workflow
-
-This repository uses the reusable [`pr-check-and-bump`](https://github.com/calavia-org/workflows-lib/blob/main/docs/pr-check-and-bump.md) workflow. When you open a PR:
-
-1. Use **conventional commit** titles (e.g. `fix:`, `feat:`, `chore:`).
-2. The workflow validates the title/commits and bumps `galaxy.yml` automatically.
-3. Version changes are committed back to the PR branch.
-
-Target branches allowed: `main`, `release/*` (for maintenance releases).
-
-## Release Process
-
-Releases are automated via `.github/workflows/release.yml`:
-
-* Semantic version tags are created from conventional commits
-* Floating major tag (`v1`, `v2`, …) is updated
-* GitHub Releases are generated with release notes
-
-See [RELEASE.md](RELEASE.md) for details.
+- macOS (Sonoma+)
+- Ubuntu (focal+)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,30 +4,69 @@ Releases for this collection are automated via `.github/workflows/release.yml`.
 
 ## How It Works
 
-When a PR is merged to `main` with a conventional commit title:
+When a PR with a conventional commit title is merged to `main`:
 
-1. The release workflow runs (`Release Collection`)
-2. It bumps the collection version in `galaxy.yml`
-3. Builds and publishes the collection to Ansible Galaxy
-4. Builds the execution environment image and pushes it to GHCR
+1. The release workflow triggers (`Release Collection`)
+2. It bumps the collection version in `galaxy.yml` based on commit types
+3. Builds and publishes the collection tarball to Ansible Galaxy
+4. Builds the execution environment (EE) image and pushes it to GHCR
 5. Creates a GitHub Release with artifacts and release notes
+6. Updates the floating major tag (`v1`, `v2`, …)
 
-## Conventional Commit → Release Type
+## Dependencies on Other Org Repos
 
-| Commit type | Result |
-|-------------|--------|
-| `fix:` | Patch release (`v1.0.0` → `v1.0.1`) |
-| `feat:` | Minor release (`v1.0.0` → `v1.1.0`) |
-| `feat!:` or `BREAKING CHANGE:` | Major release (`v1.0.0` → `v2.0.0`) |
+| Dependency | Repository | Purpose | Release Method |
+|------------|------------|---------|----------------|
+| PR validation | [`calavia-org/workflows-lib`](https://github.com/calavia-org/workflows-lib) | Reusable workflow for branch check and version bump | Manual tags (see its RELEASE.md) |
+| Version bump | [`calavia-org/bump-version-action`](https://github.com/calavia-org/bump-version-action) | Composite action used inside the reusable workflow | Automated on push to main via its own release workflow |
+
+## Versioning
+
+This repo follows **Semantic Versioning** derived from conventional commits:
+
+| Commit / PR Title | Version Bump | Example |
+|-------------------|--------------|---------|
+| `fix:` | Patch (`1.1.2` → `1.1.3`) | Bug fix |
+| `feat:` | Minor (`1.1.2` → `1.2.0`) | New feature or role |
+| `feat!:` or `BREAKING CHANGE:` | Major (`1.1.2` → `2.0.0`) | Breaking change |
+| `chore:` / `docs:` / `refactor:` | Patch (minor) | Non-functional change |
+| `doc:` | None | Documentation only |
+
+## Release Steps
+
+### 1. Version Bump (Automatic via PR)
+
+The reusable PR workflow handles this automatically:
+
+1. Checks the branch name against the allowed pattern (`^(major|feat|fix|doc)/.+`)
+2. Parses conventional commits in the PR to determine bump type
+3. Bumps `galaxy.yml` version using `bump-version-action`
+4. Commits the version bump back to the PR branch
+
+### 2. Collection Build and Publish (Automatic on Merge)
+
+The [`.github/workflows/release.yml`](.github/workflows/release.yml) workflow runs on push to `main` and:
+
+1. Runs sanity, unit, and integration tests
+2. Builds the collection tarball with `ansible-galaxy collection build`
+3. Publishes to Ansible Galaxy via `ansible-galaxy collection publish`
+4. Builds the execution environment image with `ansible-builder build`
+5. Pushes the EE image to GHCR (`ghcr.io/calavia-org/ansible-ee-setup:<version>`)
+6. Creates a GitHub Release with changelog and the built artifact
 
 ## Maintenance Releases
 
-To release a patch for an older major version:
+To release a patch for an older major version (e.g. `v1.x` while `main` is at `v2.x`):
 
-1. Create a branch from the desired tag: `git checkout -b release/v1.x v1.2.0`
-2. Apply the fix with a conventional commit (e.g. `fix:`)
+1. Create a branch from the desired release tag:
+   ```bash
+   git checkout -b release/v1.x v1.2.0
+   ```
+2. Cherry-pick or apply the fix with a conventional commit (e.g. `fix:`)
 3. Open a PR targeting `release/v1.x`
 4. The workflow bumps based on tags on that branch and publishes a patch release
+
+Target branches allowed for PRs: `main`, `release/*`.
 
 ## Post-Release Checklist
 
@@ -35,8 +74,17 @@ After the workflow completes, verify:
 
 - [ ] `galaxy.yml` version matches the GitHub Release tag
 - [ ] Collection is available on Ansible Galaxy (`jcalavia_org.setup`)
-- [ ] Execution environment image is updated on GHCR (`ghcr.io/calavia-org/ansible-ee-setup:<tag>`) |
+- [ ] EE image is updated on GHCR (`ghcr.io/calavia-org/ansible-ee-setup:<tag>`)
 - [ ] GitHub Release contains the built collection artifact
+
+## Troubleshooting
+
+| Issue | Check |
+|-------|-------|
+| Release didn't trigger | Did `galaxy.yml` change in the push to `main`? |
+| EE image push failed | Is `--container-runtime docker` set in `ansible-builder build`? |
+| Galaxy publish failed | Is `ANSIBLE_GALAXY_API_KEY` secret configured? |
+| Version bump didn't happen | Was the PR from a branch matching the allowed pattern? |
 
 ## Manual Release (Emergency)
 
@@ -50,12 +98,18 @@ git push origin vX.Y.Z
 ```
 
 Then follow the release workflow steps manually:
-- `ansible-galaxy collection build`
-- `ansible-galaxy collection publish`
-- `ansible-builder build` / `docker push`
-- Create GitHub Release with artifacts
+
+```bash
+ansible-galaxy collection build
+ansible-galaxy collection publish ./jcalavia_org-setup-X.Y.Z.tar.gz
+ansible-builder build --container-runtime docker
+docker push ghcr.io/calavia-org/ansible-ee-setup:X.Y.Z
+```
+
+And create a GitHub Release from the tag with the tarball attached.
 
 ## References
 
 - [Reusable PR Workflow](https://github.com/calavia-org/workflows-lib/blob/main/docs/pr-check-and-bump.md)
 - [Bump Version Action](https://github.com/calavia-org/bump-version-action)
+- [workflows-lib/RELEASE.md](https://github.com/calavia-org/workflows-lib/blob/main/RELEASE.md)

--- a/collections/ansible_collections/jcalavia_org/setup/README.md
+++ b/collections/ansible_collections/jcalavia_org/setup/README.md
@@ -32,7 +32,18 @@ collections:
     version: 1.0.0
 ```
 
+## Included Playbooks
+
+| Playbook | Description |
+|----------|-------------|
+| [`full_macos_setup`](./playbooks/full_macos_setup.yml) | Full macOS development environment with GPG keys and mise tools |
+| [`dev_machine`](./playbooks/dev_machine.yaml) | Basic multi-host development machine setup |
+
+See the [playbooks documentation](./playbooks/README.md) for details.
+
 ## Usage
+
+### Using Roles Directly
 
 ```yaml
 - hosts: all
@@ -44,6 +55,16 @@ collections:
     - role: nvim
     - role: opencode
     - role: mise
+```
+
+### Using a Playbook
+
+```bash
+# Full macOS setup (run locally)
+ansible-playbook jcalavia_org.setup.full_macos_setup
+
+# Basic setup on remote hosts
+ansible-playbook -i inventory jcalavia_org.setup.dev_machine
 ```
 
 ## License

--- a/collections/ansible_collections/jcalavia_org/setup/playbooks/README.md
+++ b/collections/ansible_collections/jcalavia_org/setup/playbooks/README.md
@@ -1,0 +1,121 @@
+# Playbooks — jcalavia_org.setup
+
+This collection provides two playbooks for setting up development environments.
+
+## Available Playbooks
+
+| Playbook | Description |
+|----------|-------------|
+| [`dev_machine`](./dev_machine.yaml) | Basic multi-host development machine setup |
+| [`full_macos_setup`](./full_macos_setup.yml) | Complete macOS development environment with GPG keys and mise tools |
+
+---
+
+## dev_machine
+
+Basic development machine setup targeting any host.
+
+### Synopsis
+
+Installs git, Neovim, tmux, and OpenCode on one or more remote hosts. Suitable for Ubuntu and macOS targets.
+
+### Requirements
+
+- Ansible 2.19+
+- Target host(s) reachable via SSH
+- Python 3.12+ on target hosts
+
+### Usage
+
+```bash
+ansible-playbook -i inventory jcalavia_org.setup.dev_machine
+```
+
+### Playbook Content
+
+```yaml
+- hosts: all
+  roles:
+    - jcalavia_org.setup.git
+    - jcalavia_org.setup.nvim
+    - jcalavia_org.setup.tmux
+    - jcalavia_org.setup.opencode
+```
+
+### Variables
+
+This playbook accepts all role variables from its included roles (see each role's README).
+
+---
+
+## full_macos_setup
+
+Complete macOS development environment setup for localhost.
+
+### Synopsis
+
+Configures a local macOS machine with the full development toolchain: git identity, GPG key generation, tmux with TPM persistence, Neovim with IDE plugins, OpenCode with Engram memory plugin, and mise with Python, Java, Node.js, and Go.
+
+### Requirements
+
+- macOS (Sonoma+)
+- Ansible 2.19+
+- Python 3.12+
+- Homebrew (used by most roles on Darwin)
+
+### Usage
+
+```bash
+ansible-playbook jcalavia_org.setup.full_macos_setup
+```
+
+### Playbook Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `git_user_name` | `{{ lookup("env", "USER") }}` | Git user name, also used for GPG key generation |
+| `git_user_email` | `{{ lookup("env", "USER") }}@{{ ansible_hostname }}` | Git user email, also used for GPG key generation |
+| `gpg_key_manage` | `true` | Enable GPG key generation |
+| `gpg_key_real_name` | `{{ git_user_name }}` | Real name for the GPG key |
+| `gpg_key_email` | `{{ git_user_email }}` | Email for the GPG key |
+| `gpg_key_export_public` | `true` | Export public key after generation |
+| `opencode_engram_enable` | `true` | Enable the Engram memory plugin |
+| `opencode_opentmux_enable` | `true` | Enable the OpenTmux tmux integration |
+| `mise_python_enable` | `true` | Install and set global Python (3.12) |
+| `mise_java_enable` | `true` | Install and set global Java (temurin-21) |
+| `mise_node_enable` | `true` | Install and set global Node.js (22) |
+| `mise_go_enable` | `true` | Install and set global Go (latest) |
+
+### Roles Applied
+
+```yaml
+roles:
+  - role: git
+    git_gpg_sign: true
+  - role: gpg
+  - role: tmux
+    tmux_tpm_enable: true
+  - role: nvim
+  - role: opencode
+  - role: mise
+```
+
+### Example with Overrides
+
+```yaml
+# playbook override example: custom GPG key and Java version
+ansible-playbook jcalavia_org.setup.full_macos_setup \
+  -e gpg_key_real_name="Your Name" \
+  -e gpg_key_email="you@example.com" \
+  -e mise_java_version="openjdk-21"
+```
+
+---
+
+## License
+
+GPL-2.0-or-later
+
+## Author
+
+Jorge Calavia <jorge@calavia.org>


### PR DESCRIPTION
- Root README.md: trim to minimal repo overview with docs table.
- RELEASE.md: expand with versioning strategy, troubleshooting, manual release.
- Collection README: add playbooks section with usage examples.
- playbooks/README.md: new Ansible-style doc for both playbooks.