### PR TITLE
feat(ci): add unified pr-check-and-test workflow

### DIFF
--- a/.github/workflows/pr-check-and-test.yml
+++ b/.github/workflows/pr-check-and-test.yml
@@ -1,0 +1,52 @@
+name: PR Check and Test
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    paths:
+      - collections/ansible_collections/calaviaorg/setup/playbooks/**
+      - collections/ansible_collections/calaviaorg/setup/plugins/**
+      - collections/ansible_collections/calaviaorg/setup/roles/**
+      - tests/**
+      - extensions/molecule/**
+      - galaxy.yml
+      - requirements.yml
+      - tox-ansible.ini
+      - .github/workflows/pr-check-and-test.yml
+      - .pre-commit-config.yaml
+      - pyproject.toml
+      - setup.py
+      - setup.cfg
+      - requirements.txt
+
+jobs:
+  pr-check-and-test:
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1
+    with:
+      technology: auto
+      run-pre-commit: true
+      run-lint: true
+      run-build: false
+      run-tests: true
+      run-unit-tests: true
+      run-integration-tests: true
+      run-e2e-tests: false
+      run-package: false
+      run-publish: false
+      fail-on-missing: false
+      python-version: '3.12'
+      tox-ini: 'tox-ansible.ini'
+      ansible-collection-path: 'collections/ansible_collections/calaviaorg/setup'
+      test-timeout: 30
+      max-parallel: 4
+      fail-fast: false
+      cache-enabled: true
+      report-enabled: true
+      coverage-format: xml
+      coverage-tool: codecov
+      comment-on-pr: true
+      summary-title: 'Ansible Collection CI'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,8 @@
-name: Test collection
+# ⚠️ DEPRECATED: This workflow is superseded by pr-check-and-test.yml
+# which uses the unified calavia-org/workflows-lib reusable workflow.
+# It is kept temporarily for reference during the migration period.
+# Remove this file after pr-check-and-test.yml is validated.
+name: Test collection (deprecated)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,9 @@
+# ⚠️ DEPRECATED: This workflow is superseded by pr-check-and-test.yml
+# which uses the unified calavia-org/workflows-lib reusable workflow.
+# It is kept temporarily for reference during the migration period.
+# Remove this file after pr-check-and-test.yml is validated.
 ---
-name: pre-commit
+name: pre-commit (deprecated)
 
 on:
   pull_request:

--- a/.sisyphus/drafts/unified-pre-commit-test.md
+++ b/.sisyphus/drafts/unified-pre-commit-test.md
@@ -1,0 +1,66 @@
+# Unified Pre-Commit & Test Reusable Workflow
+
+## Draft - Requirements Gathering
+
+### Core Objective
+Create a centralized, reusable GitHub Actions workflow in `calavia-org/workflows-lib` that standardizes pre-commit validation, static analysis, testing, and packaging across all repositories in the organization, regardless of technology stack.
+
+### Key Requirements
+1. **Reusable workflow**: New `pr-check-and-test.yml` in `workflows-lib` using `workflow_call`
+2. **Technology support**: Python, Node.js, Go, Rust, Docker, Java, Ansible (python-based)
+3. **Unified workflow**: Single workflow with input parameters to enable/disable specific phases
+4. **Pre-commit integration**:
+   - Run first as fail-fast gate
+   - Configurable per-technology (pre-commit for Python, husky for Node.js, etc.)
+   - Default to `.pre-commit-config.yaml` if present
+   - Fail if no config found and `fail-on-missing: true`
+5. **Configurable phases**: Pre-commit, lint, build, test (unit, integration, e2e), package, publish
+6. **Technology auto-detection**: Scan repo for indicators (e.g., `package.json`, `go.mod`, `Cargo.toml`, etc.)
+7. **Change detection**: Only run phases for changed files (like current `pr.yml`)
+8. **Matrix support**: Support matrix builds across versions/platforms
+
+### Current State Analysis
+- `pre-commit.yml`: Simple, runs on all files, no change detection
+- `pr.yml`: Complex Ansible-specific with tox matrix, change detection, molecule tests
+- `release.yml`: Build, publish, create release
+- `pr-check-and-bump.yml`: Already uses `workflows-lib` pattern
+
+### Decisions to Make
+- Where to store the unified workflow? `workflows-lib/.github/workflows/pr-check-and-test.yml`
+- How to handle technology-specific defaults? Composite actions per technology
+- What about monorepos? Support for multiple technologies in one repo
+- How to handle test reporting? JUnit, coverage, SARIF
+- What about security scanning? SAST, dependency scanning, container scanning
+- How to handle caching? Per-technology cache keys
+- What about parallel execution? Job dependencies and parallelization
+
+### Constraints
+- Must be backwards compatible with existing workflows
+- Must work for both PR and push triggers
+- Must support custom runner labels
+- Must fail gracefully when tools are missing
+- Must produce consistent artifacts
+
+### Questions to Resolve
+1. Should we support custom pre-commit hooks per repo?
+2. Should we include security scanning (SAST, DAST, dependency check)?
+3. Should we support container image scanning?
+4. How to handle test result aggregation?
+5. Should we support manual dispatch with custom parameters?
+6. How to handle notifications (Slack, Teams, email)?
+7. Should we include performance testing gates?
+8. How to handle artifacts retention?
+
+### Target Repositories
+- `ansible-collection-setup` (Ansible/Python)
+- `base-template` (generic)
+- Other repos in `calavia-org`
+
+### Success Criteria
+- [ ] New workflow published in `workflows-lib`
+- [ ] Consumer repos can call it with simple inputs
+- [ ] Auto-detection works for all supported technologies
+- [ ] Pre-commit runs first and fails fast
+- [ ] All test phases are optional and configurable
+- [ ] Reports are published and accessible
+- [ ] Documentation is complete

--- a/.sisyphus/plans/unified-pre-commit-test.md
+++ b/.sisyphus/plans/unified-pre-commit-test.md
@@ -1,0 +1,293 @@
+# Unified Pre-Commit & Test Reusable Workflow
+
+## Goal
+
+Create a centralized, reusable GitHub Actions workflow in `calavia-org/workflows-lib` that standardizes pre-commit validation, static analysis, testing, and packaging across all repositories in the organization, regardless of technology stack.
+
+## Background
+
+Currently, each repository maintains its own CI/CD workflows:
+- `pre-commit.yml` - simple pre-commit run
+- `pr.yml` - complex Ansible-specific tox matrix
+- `release.yml` - build, publish, release
+
+This leads to duplicated logic, inconsistent standards, and maintenance overhead when CI best practices change. The `pr-check-and-bump.yml` already uses the `workflows-lib` pattern successfully, proving this approach works.
+
+## Technical Decisions
+
+### Architecture
+- **Repository**: `calavia-org/workflows-lib`
+- **Workflow**: `.github/workflows/pr-check-and-test.yml`
+- **Pattern**: Reusable workflow with `workflow_call` trigger
+- **Technology Detection**: Composite actions per technology stack
+
+### Workflow Structure
+```
+pr-check-and-test.yml (reusable)
+├── Phase 1: Detect Technology
+├── Phase 2: Pre-Commit (fail-fast)
+├── Phase 3: Static Analysis
+├── Phase 4: Build
+├── Phase 5: Test (unit, integration, e2e)
+├── Phase 6: Package
+├── Phase 7: Publish (optional)
+└── Phase 8: Report
+```
+
+### Technology Detection Order
+1. `galaxy.yml` → Ansible
+2. `pyproject.toml` / `setup.py` / `setup.cfg` / `requirements.txt` → Python
+3. `package.json` → Node.js
+4. `go.mod` → Go
+5. `Cargo.toml` → Rust
+6. `pom.xml` / `build.gradle` → Java
+7. `Dockerfile` / `docker-compose.yml` → Docker
+8. `VERSION` / `version.txt` → Generic
+
+### Input Parameters
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `technology` | string | `auto` | Technology stack or auto-detect |
+| `run-pre-commit` | boolean | `true` | Run pre-commit hooks |
+| `run-lint` | boolean | `true` | Run static analysis |
+| `run-build` | boolean | `true` | Run build step |
+| `run-tests` | boolean | `true` | Run all tests |
+| `run-unit-tests` | boolean | `true` | Run unit tests |
+| `run-integration-tests` | boolean | `true` | Run integration tests |
+| `run-e2e-tests` | boolean | `false` | Run end-to-end tests |
+| `run-package` | boolean | `false` | Run packaging step |
+| `run-publish` | boolean | `false` | Run publish step |
+| `fail-on-missing` | boolean | `false` | Fail if config file missing |
+| `custom-pre-commit-config` | string | `` | Path to custom pre-commit config |
+| `test-command` | string | `` | Override test command |
+| `lint-command` | string | `` | Override lint command |
+| `build-command` | string | `` | Override build command |
+| `package-command` | string | `` | Override package command |
+| `publish-command` | string | `` | Override publish command |
+| `runner-label` | string | `ubuntu-latest` | Runner label |
+| `timeout-minutes` | number | `30` | Global timeout |
+| `artifact-retention-days` | number | `7` | Artifact retention |
+| `cache-enabled` | boolean | `true` | Enable caching |
+| `report-enabled` | boolean | `true` | Publish test reports |
+
+### Per-Technology Defaults
+
+**Python/Ansible**
+- Pre-commit: `.pre-commit-config.yaml` (if exists)
+- Lint: `ruff check .` or `flake8` or `pylint`
+- Build: `python -m build` or `poetry build`
+- Test: `pytest` or `tox` or `ansible-test`
+- Package: `wheel`, `sdist`, `ansible-galaxy collection build`
+- Publish: `twine upload` or `ansible-galaxy collection publish`
+
+**Node.js**
+- Pre-commit: `.husky/` (if exists) or `lint-staged`
+- Lint: `eslint` or `prettier --check`
+- Build: `npm run build` or `yarn build`
+- Test: `npm test` or `jest`
+- Package: `npm pack`
+- Publish: `npm publish`
+
+**Go**
+- Pre-commit: `golangci-lint` (if configured)
+- Lint: `golangci-lint run` or `go vet ./...`
+- Build: `go build ./...`
+- Test: `go test ./...`
+- Package: `go build` with output
+- Publish: `go get` or Docker image
+
+**Rust**
+- Pre-commit: `cargo clippy` or `rustfmt`
+- Lint: `cargo clippy` or `cargo fmt --check`
+- Build: `cargo build --release`
+- Test: `cargo test`
+- Package: `cargo package`
+- Publish: `cargo publish`
+
+**Java**
+- Pre-commit: `spotless` or `checkstyle` (if configured)
+- Lint: `mvn checkstyle:check` or `gradle check`
+- Build: `mvn package` or `gradle build`
+- Test: `mvn test` or `gradle test`
+- Package: `mvn package` or `gradle jar`
+- Publish: `mvn deploy` or `gradle publish`
+
+**Docker**
+- Pre-commit: `hadolint` or `dockerfilelint` (if configured)
+- Lint: `hadolint Dockerfile` or `dockerfilelint`
+- Build: `docker build`
+- Test: `container-structure-test` or `dgoss`
+- Package: `docker save` or `docker push`
+- Publish: `docker push` or `skaffold run`
+
+**Generic**
+- Pre-commit: `pre-commit` if `.pre-commit-config.yaml` exists
+- Lint: `shellcheck` for shell scripts
+- Build: `make` if `Makefile` exists
+- Test: `make test` if available
+- Package: `tar` or `zip`
+- Publish: Manual or custom script
+
+## Plan
+
+### Phase 1: Infrastructure Setup
+1. Create `calavia-org/workflows-lib` repository structure
+2. Create `.github/workflows/pr-check-and-test.yml`
+3. Create `.github/actions/` directory for composite actions
+4. Create composite actions for each technology:
+   - `detect-technology`
+   - `setup-pre-commit`
+   - `setup-python`
+   - `setup-nodejs`
+   - `setup-go`
+   - `setup-rust`
+   - `setup-java`
+   - `setup-docker`
+   - `run-tests`
+   - `publish-reports`
+
+### Phase 2: Core Workflow Implementation
+1. Implement `detect-technology` composite action
+   - Scan for technology indicators
+   - Output detected technology list
+   - Support multiple technologies (monorepos)
+2. Implement `setup-pre-commit` composite action
+   - Check for `.pre-commit-config.yaml`
+   - Install pre-commit
+   - Run `pre-commit run --all-files` or `pre-commit run --from-ref`
+   - Support custom config path
+   - Support per-technology hooks
+3. Implement `pr-check-and-test.yml` reusable workflow
+   - Job 1: Detect technology
+   - Job 2: Pre-commit (fail-fast)
+   - Job 3: Lint (parallel per technology)
+   - Job 4: Build (parallel per technology)
+   - Job 5: Test (matrix per technology)
+   - Job 6: Package (optional)
+   - Job 7: Publish (optional)
+   - Job 8: Report aggregation
+
+### Phase 3: Test Matrix & Change Detection
+1. Implement change detection logic
+   - Compare PR head vs base
+   - Filter changed files by technology
+   - Determine which tests to run
+2. Implement test matrix generation
+   - Per-technology test commands
+   - Version matrix support
+   - Platform matrix support
+3. Implement test result collection
+   - JUnit XML parsing
+   - Coverage report collection
+   - SARIF report collection
+
+### Phase 4: Reporting & Artifacts
+1. Implement report aggregation
+   - Test results summary
+   - Coverage report
+   - Lint results
+   - Security scan results
+2. Implement artifact publishing
+   - Test reports
+   - Coverage reports
+   - Build artifacts
+   - Package artifacts
+
+### Phase 5: Consumer Migration
+1. Update `ansible-collection-setup`
+   - Create `.github/workflows/pr-check-and-test.yml` caller
+   - Delete `pre-commit.yml`
+   - Delete `pr.yml` (or keep for specific cases)
+   - Update `release.yml` to use new workflow
+2. Update documentation
+   - Migration guide
+   - Configuration reference
+   - Troubleshooting
+
+## TODOs
+
+- [ ] Create `workflows-lib` repository structure
+- [ ] Implement `detect-technology` composite action
+- [ ] Implement `setup-pre-commit` composite action
+- [ ] Implement `pr-check-and-test.yml` reusable workflow skeleton
+- [ ] Add Python/Ansible support
+- [ ] Add Node.js support
+- [ ] Add Go support
+- [ ] Add Rust support
+- [ ] Add Java support
+- [ ] Add Docker support
+- [ ] Implement change detection
+- [ ] Implement test matrix generation
+- [ ] Implement test result collection
+- [ ] Implement report aggregation
+- [ ] Implement artifact publishing
+- [ ] Write migration guide
+- [ ] Update `ansible-collection-setup` workflows
+- [ ] Test on `ansible-collection-setup`
+- [ ] Test on `base-template`
+- [ ] Publish documentation
+
+## Acceptance Criteria
+
+- [ ] The workflow can be called from any repository with `uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1`
+- [ ] Auto-detection works for all supported technologies
+- [ ] Pre-commit runs first and fails fast
+- [ ] All test phases are optional and configurable
+- [ ] Reports are published and accessible
+- [ ] Consumer repos can override defaults per-technology
+- [ ] Monorepo support works (multiple technologies in one repo)
+- [ ] Migration from existing workflows is documented
+- [ ] Performance is acceptable (caching works)
+- [ ] Error messages are clear and actionable
+
+## Execution Strategy
+
+### Dependencies
+1. Infrastructure setup must complete before composite actions
+2. Composite actions must complete before core workflow
+3. Core workflow must complete before testing
+4. Testing must complete before consumer migration
+
+### Parallelization
+- Infrastructure + Composite actions (Phase 1-2): Can be done in parallel
+- Technology support (Phase 2): Can be added incrementally
+- Testing and reporting (Phase 3-4): Can be done in parallel with technology support
+- Consumer migration (Phase 5): Depends on all previous phases
+
+### Risk Mitigation
+- **Risk**: Breaking existing workflows during migration
+  - **Mitigation**: Gradual migration, keep old workflows until new ones are verified
+- **Risk**: Technology auto-detection fails
+  - **Mitigation**: Allow explicit technology override, fail gracefully
+- **Risk**: Performance issues with large repos
+  - **Mitigation**: Change detection, caching, configurable timeouts
+- **Risk**: Monorepo complexity
+  - **Mitigation**: Phase-by-phase execution, technology-specific filtering
+
+## Verification Strategy
+
+1. **Unit Testing**: Test composite actions in isolation
+2. **Integration Testing**: Test full workflow on sample repos
+3. **End-to-End Testing**: Test on `ansible-collection-setup` and `base-template`
+4. **Performance Testing**: Measure execution time vs old workflows
+5. **Security Testing**: Ensure secrets handling is correct
+6. **Regression Testing**: Ensure existing workflows still work
+
+## Commit Strategy
+
+- Phase 1: `feat(ci): add infrastructure for unified test workflow`
+- Phase 2: `feat(ci): implement core workflow and composite actions`
+- Phase 3: `feat(ci): add test matrix and change detection`
+- Phase 4: `feat(ci): add reporting and artifact publishing`
+- Phase 5: `feat(ci): migrate ansible-collection-setup to new workflow`
+- Phase 6: `docs(ci): add migration guide and configuration reference`
+
+## Notes
+
+- The workflow should be designed to be extensible for new technologies
+- Consider using `actions/cache` for per-technology caching
+- Consider using `actions/upload-artifact` for build artifacts
+- Consider using `EnricoMi/publish-unit-test-result-action` for test results
+- Consider using `codecov/codecov-action` for coverage reports
+- The workflow should support both `pull_request` and `push` triggers
+- The workflow should support `workflow_dispatch` for manual testing

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,250 @@
+# Migration Guide: Unified Pre-Commit & Test Workflow
+
+## Overview
+
+This guide explains how to migrate from per-repository CI/CD workflows to the centralized `pr-check-and-test.yml` reusable workflow in `calavia-org/workflows-lib`.
+
+## What Changed
+
+### Before
+- `pre-commit.yml` - standalone pre-commit runner
+- `pr.yml` - Ansible-specific test matrix with tox
+- `release.yml` - build, publish, release
+- Each repo maintained its own CI logic
+
+### After
+- `pr-check-and-test.yml` - unified caller workflow that delegates to `calavia-org/workflows-lib`
+- Technology auto-detection (Python, Node.js, Go, Rust, Java, Docker, Ansible)
+- Configurable phases (pre-commit, lint, build, test, package, publish)
+- Centralized maintenance and updates
+
+## Migration Steps
+
+### 1. Create Caller Workflow
+
+Create `.github/workflows/pr-check-and-test.yml` in your repository:
+
+```yaml
+name: PR Check and Test
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  pr-check-and-test:
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1
+    with:
+      technology: auto
+      run-pre-commit: true
+      run-lint: true
+      run-build: true
+      run-tests: true
+      run-unit-tests: true
+      run-integration-tests: true
+      fail-on-missing: false
+      python-version: '3.12'
+      cache-enabled: true
+      report-enabled: true
+      comment-on-pr: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+### 2. Configure Inputs
+
+#### Required Inputs
+| Input | Description | Example |
+|-------|-------------|---------|
+| `technology` | Technology stack or `auto` for auto-detection | `auto`, `python`, `nodejs`, `go` |
+| `run-pre-commit` | Enable pre-commit hooks | `true` or `false` |
+| `run-tests` | Enable test execution | `true` or `false` |
+
+#### Technology-Specific Inputs
+| Input | For Technology | Description |
+|-------|---------------|-------------|
+| `python-version` | Python/Ansible | Python version (default: `3.12`) |
+| `node-version` | Node.js | Node.js version (default: `20`) |
+| `go-version` | Go | Go version (default: `1.22`) |
+| `rust-toolchain` | Rust | Rust toolchain (default: `stable`) |
+| `java-version` | Java | Java version (default: `21`) |
+| `tox-ini` | Python/Ansible | Path to tox.ini (default: `tox.ini`) |
+| `ansible-collection-path` | Ansible | Path to collection directory |
+
+#### Optional Overrides
+| Input | Description |
+|-------|-------------|
+| `test-command` | Override test command |
+| `lint-command` | Override lint command |
+| `build-command` | Override build command |
+| `package-command` | Override package command |
+| `publish-command` | Override publish command |
+
+### 3. Deprecate Old Workflows
+
+Add deprecation notices to old workflows:
+
+```yaml
+# ⚠️ DEPRECATED: This workflow is superseded by pr-check-and-test.yml
+# which uses the unified calavia-org/workflows-lib reusable workflow.
+# Remove this file after pr-check-and-test.yml is validated.
+```
+
+### 4. Technology-Specific Configuration
+
+#### Python/Ansible
+- Ensure `tox.ini` or `tox-ansible.ini` exists
+- Ensure `.pre-commit-config.yaml` exists
+- Set `python-version` to match your project
+- Set `ansible-collection-path` if applicable
+
+#### Node.js
+- Ensure `package.json` has `test`, `lint`, and `build` scripts
+- Ensure `.husky/pre-commit` or lint-staged is configured
+- Set `node-version` to match your project
+
+#### Go
+- Ensure `go.mod` exists
+- Ensure `.golangci.yml` exists for linting
+- Set `go-version` to match your `go.mod`
+
+#### Rust
+- Ensure `Cargo.toml` exists
+- Set `rust-toolchain` to match your project
+
+#### Java
+- Ensure `pom.xml` or `build.gradle` exists
+- Set `java-version` and `java-distribution` to match your project
+
+#### Docker
+- Ensure `Dockerfile` exists
+- Ensure `.hadolint.yaml` exists for linting
+
+#### Generic
+- Ensure `Makefile` exists with `test`, `lint`, `build`, `package` targets
+- Or provide custom commands via inputs
+
+### 5. Secrets Configuration
+
+Add these secrets to your repository if needed:
+
+| Secret | Required For | Description |
+|--------|-------------|-------------|
+| `GITHUB_TOKEN` | Always | Provided by GitHub Actions |
+| `CODECOV_TOKEN` | Coverage reports | Codecov upload token |
+| `SLACK_WEBHOOK_URL` | Notifications | Slack webhook URL |
+
+### 6. Testing the Migration
+
+1. Create a test PR
+2. Verify the new workflow runs successfully
+3. Check that all phases execute correctly
+4. Verify test reports are published
+5. Verify coverage reports are uploaded (if applicable)
+6. Check PR comments are posted (if enabled)
+
+### 7. Cleanup
+
+After validating the new workflow:
+1. Delete `pre-commit.yml`
+2. Delete `pr.yml`
+3. Update `release.yml` if needed
+4. Update documentation
+
+## Troubleshooting
+
+### Common Issues
+
+**1. Technology not detected**
+- Set `technology` explicitly instead of `auto`
+- Check that indicator files exist (e.g., `package.json`, `go.mod`, `Cargo.toml`)
+
+**2. Pre-commit fails**
+- Check `.pre-commit-config.yaml` exists
+- Set `custom-pre-commit-config` if using non-standard location
+- Set `fail-on-missing: false` to skip if not configured
+
+**3. Tests not found**
+- Check `test-command` override or use technology-specific defaults
+- Ensure test files exist in standard locations
+- Check `test-paths` if tests are in non-standard locations
+
+**4. Coverage not uploaded**
+- Check `CODECOV_TOKEN` is set
+- Check `coverage-format` matches your tool output
+- Verify coverage files are generated
+
+**5. Workflow not triggered**
+- Check `on:` triggers match your events
+- Check `paths:` filters if using path filtering
+- Ensure workflow file is in `.github/workflows/`
+
+### Getting Help
+
+- Check the [workflows-lib README](https://github.com/calavia-org/workflows-lib)
+- Review the [plan document](.sisyphus/plans/unified-pre-commit-test.md)
+- Open an issue in `calavia-org/workflows-lib`
+
+## Example Configurations
+
+### Python Project
+```yaml
+jobs:
+  pr-check-and-test:
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1
+    with:
+      technology: python
+      run-pre-commit: true
+      run-tests: true
+      python-version: '3.11'
+      tox-ini: 'tox.ini'
+      test-timeout: 20
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+### Node.js Project
+```yaml
+jobs:
+  pr-check-and-test:
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1
+    with:
+      technology: nodejs
+      run-pre-commit: true
+      run-build: true
+      run-tests: true
+      node-version: '18'
+      test-timeout: 15
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Monorepo (Multiple Technologies)
+```yaml
+jobs:
+  pr-check-and-test:
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1
+    with:
+      technology: auto
+      run-pre-commit: true
+      run-lint: true
+      run-build: true
+      run-tests: true
+      fail-on-missing: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| v1.0.0 | 2024-01-XX | Initial release |
+
+## References
+
+- [GitHub Actions: Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+- [Prometheus Plan](.sisyphus/plans/unified-pre-commit-test.md)
+- [workflows-lib Repository](https://github.com/calavia-org/workflows-lib)

--- a/collections/ansible_collections/calaviaorg/setup/galaxy.yml
+++ b/collections/ansible_collections/calaviaorg/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: calaviaorg
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.0
+version: 1.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
This PR introduces the unified PR check and test workflow using the centralized reusable workflow from workflows-lib.

## Changes
- Add pr-check-and-test.yml caller workflow using workflows-lib
- Deprecate pr.yml and pre-commit.yml (superseded by unified workflow)
- Add migration documentation (MIGRATION.md)
- Add Prometheus plan artifacts (.sisyphus/)

## Migration
See MIGRATION.md for details on how to use the new unified workflow.

## Testing
- [ ] Verify new workflow runs on this PR
- [ ] Check deprecated workflows still run (for backward compatibility)
- [ ] Confirm test reports are published
- [ ] Validate coverage upload works