### PR TITLE
fix(ci): correct reusable workflow version tag from v1 to v0

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   release:
-    uses: calavia-org/workflows-lib/.github/workflows/release-artifacts.yml@v1
+    uses: calavia-org/workflows-lib/.github/workflows/release-artifacts.yml@v0
     with:
       technology: ansible
       artifacts: binary,docker

--- a/collections/ansible_collections/calaviaorg/setup/galaxy.yml
+++ b/collections/ansible_collections/calaviaorg/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: calaviaorg
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.5.0
+version: 1.5.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
The release-artifacts caller workflow was referencing "@v1" which does not exist. The v0 tag tracks the latest v0.x.x release.

## Changes
- Fixed version tag from v1 to v0 in .github/workflows/release-artifacts.yml
- Aligns with version strategy documented in workflows-lib README

## Context
- workflows-lib v0 tag is maintained to track latest v0.x.x release
- v0.0.2 is the current fixed release if pinning is needed
- When major version 1 is released, we will pin to v1.0.0 or later