### PR TITLE
feat(ci): enable ansible execution environment build

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -38,6 +38,8 @@ jobs:
       rollback-on-failure: true
       notify-on-release: true
       ansible-collection-path: collections/ansible_collections/calaviaorg/setup
+      is-ansible-ee: true
+      ee-definition-file: execution-environment.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       package-token: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}


### PR DESCRIPTION
This PR enables the Ansible Execution Environment build in the release workflow.

## Changes
- Add "is-ansible-ee: true" to build EE image via ansible-builder
- Add "ee-definition-file: execution-environment.yml" input
- Uses latest workflows-lib@v0 with EE support

## Why
The release workflow now supports building both the Ansible collection binary and the Execution Environment Docker image. The EE image is built using ansible-builder and published to GHCR.

## Related
- workflows-lib PR #10 (feat/ci): add ansible execution environment inputs