### PR TITLE
fix(ci): align pr-check-and-test workflow version from v1 to v0

### DIFF
--- a/.github/workflows/pr-check-and-test.yml
+++ b/.github/workflows/pr-check-and-test.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   pr-check-and-test:
-    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v1
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v0
     with:
       technology: auto
       run-pre-commit: true


### PR DESCRIPTION
Changes the workflow reference from @v1 to @v0 which doesn't exist. v0 is the floating major tag.