### PR TITLE
doc: update obsolete documentation to reflect current workflow architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,75 @@
-# CONTRIBUITNG
+# Contributing to calaviaorg.setup
+
+Thank you for your interest in contributing! This collection is managed with automated CI workflows and strict conventions.
+
+## Prerequisites
+
+- Python 3.12+
+- Ansible 2.19+
+- `tox-ansible` installed (`pip install tox-ansible`)
+
+## Development Setup
+
+```bash
+git clone https://github.com/calavia-org/ansible-collection-setup.git
+cd ansible-collection-setup
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+```bash
+# Unit tests
+tox -e unit-py3.12-milestone --ansible --conf tox-ansible.ini
+
+# Sanity tests
+tox -e sanity-py3.12-milestone --ansible --conf tox-ansible.ini
+
+# Integration tests (molecule)
+tox -e integration-py3.12-milestone --ansible --conf tox-ansible.ini
+```
+
+## Linting
+
+```bash
+ruff format .
+ruff check . --fix
+pre-commit run --all-files
+ansible-lint
+yamllint -c .yamllint .
+```
+
+## Branch Naming
+
+All branches **must** follow the pattern `^(major|feat|fix|doc|chore)/.+`:
+
+| Prefix | Version Bump | Use Case |
+|--------|--------------|----------|
+| `fix/` | Patch | Bug fixes |
+| `feat/` | Minor | New features or roles |
+| `major/` | Major | Breaking changes |
+| `doc/` | None | Documentation only |
+| `chore/` | None | CI, tooling, non-functional changes |
+
+## Commit Convention
+
+- Squash merge is required
+- PR title must follow conventional commits: `type(scope): description`
+- Examples: `fix(ci): correct workflow version`, `feat(role): add tmux configuration`
+
+## PR Workflow
+
+1. Create a branch from `main` with the correct prefix
+2. Make your changes
+3. Run tests and linting locally
+4. Open a PR targeting `main`
+5. The reusable workflow will auto-bump `galaxy.yml` version before merge (unless `chore/` branch)
+
+## Release Process
+
+See [`RELEASE.md`](RELEASE.md) for the full release process.
+
+## Questions?
+
+Open an issue or reach out to the maintainers.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ git clone https://github.com/calavia-org/ansible-collection-setup.git
 cd ansible-collection-setup
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-tox -e unit-py3.12-2.17 --ansible --conf tox-ansible.ini
+tox -e unit-py3.12-milestone --ansible --conf tox-ansible.ini
 ```
+
+## CI / Workflows
+
+| Workflow | Purpose | Status |
+|----------|---------|--------|
+| [`pr-check-and-bump`](.github/workflows/pr-check-and-bump.yml) | Validate branch name, conventional commits, auto-bump version | Active |
+| [`pr-check-and-test`](.github/workflows/pr-check-and-test.yml) | Lint, test, build (reusable from `calavia-org/workflows-lib`) | Active |
+| [`release-artifacts`](.github/workflows/release-artifacts.yml) | Build and publish collection + EE image on merge | Active |
 
 ## Supported Platforms
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ This document describes how to release new versions of the `ansible-collection-s
 
 When a PR with a conventional commit title is merged to `main`:
 
-1. The release workflow triggers (`Release Collection`)
-2. It bumps the collection version in `galaxy.yml` based on commit types
+1. The PR workflow auto-bumps the collection version in `galaxy.yml` (if not a `chore/` branch)
+2. The release workflow triggers on push to `main` when `galaxy.yml` changes
 3. Builds and publishes the collection tarball to Ansible Galaxy
 4. Builds the execution environment (EE) image and pushes it to GHCR
 5. Creates a GitHub Release with artifacts and release notes
@@ -17,7 +17,7 @@ When a PR with a conventional commit title is merged to `main`:
 
 | Dependency | Repository | Purpose | Release Method |
 |------------|------------|---------|----------------|
-| PR validation | [`calavia-org/workflows-lib`](https://github.com/calavia-org/workflows-lib) | Reusable workflow for branch check and version bump | Manual tags (see its RELEASE.md) |
+| PR validation + test | [`calavia-org/workflows-lib`](https://github.com/calavia-org/workflows-lib) | Reusable workflows for branch check, version bump, lint, test | Manual tags (`v0`) |
 | Version bump | [`calavia-org/bump-version-action`](https://github.com/calavia-org/bump-version-action) | Composite action used inside the reusable workflow | Automated on push to main via its own release workflow |
 
 ## Versioning
@@ -30,29 +30,35 @@ This repo follows **Semantic Versioning** derived from conventional commits:
 | `feat:` | Minor (`1.1.2` → `1.2.0`) | New feature or role |
 | `feat!:` or `BREAKING CHANGE:` | Major (`1.1.2` → `2.0.0`) | Breaking change |
 | `chore:` / `docs:` / `refactor:` | **None** | Non-functional change (checks still run) |
-| `doc:` | None | Documentation only
+| `doc:` | None | Documentation only |
 
-## Release Steps
+## Workflows
 
-### 1. Version Bump (Automatic via PR)
+### PR Check and Auto-Bump
 
-The reusable PR workflow handles this automatically:
+[`pr-check-and-bump.yml`](.github/workflows/pr-check-and-bump.yml) — calls `calavia-org/workflows-lib/.github/workflows/pr-check-and-bump.yml@v0`:
 
-1. Checks the branch name against the allowed pattern (`^(major|feat|fix|doc|chore)/.+`)
-2. Parses conventional commits in the PR to determine bump type
-3. For `chore/` branches: runs all checks but **skips** the version bump (handled by the centralized reusable workflow)
-4. For other branches: bumps `galaxy.yml` version using `bump-version-action` and commits back to the PR branch
+1. Validates branch name against `^(major|feat|fix|doc|chore)/.+`
+2. Parses conventional commits for bump type
+3. For `chore/` branches: skips the version bump
+4. For other branches: auto-bumps `galaxy.yml` version
 
-### 2. Collection Build and Publish (Automatic on Merge)
+### PR Check and Test
 
-The [`.github/workflows/release.yml`](.github/workflows/release.yml) workflow runs on push to `main` and:
+[`pr-check-and-test.yml`](.github/workflows/pr-check-and-test.yml) — calls `calavia-org/workflows-lib/.github/workflows/pr-check-and-test.yml@v0`:
 
-1. Runs sanity, unit, and integration tests
-2. Builds the collection tarball with `ansible-galaxy collection build`
-3. Publishes to Ansible Galaxy via `ansible-galaxy collection publish`
-4. Builds the execution environment image with `ansible-builder build`
-5. Pushes the EE image to GHCR (`ghcr.io/calavia-org/ansible-ee-setup:<version>`)
-6. Creates a GitHub Release with changelog and the built artifact
+- Detects technology, runs lint, tests, and coverage
+- Skips build/publish steps (those happen on merge)
+
+### Release Artifacts
+
+[`release-artifacts.yml`](.github/workflows/release-artifacts.yml) — calls `calavia-org/workflows-lib/.github/workflows/release-artifacts.yml@v0`:
+
+1. Detects version from `galaxy.yml`
+2. Builds collection tarball
+3. Publishes to Ansible Galaxy
+4. Builds EE image and pushes to GHCR
+5. Creates GitHub Release
 
 ## Maintenance Releases
 
@@ -70,13 +76,6 @@ Target branches allowed for PRs: `main`, `release/*`.
 
 ## Post-Release Checklist
 
-| Issue | Check |
-|-------|-------|
-| Release didn't trigger | Did `galaxy.yml` change in the push to `main`? |
-| EE image push failed | Is `--container-runtime docker` set in `ansible-builder build`? |
-| Galaxy publish failed | Is `ANSIBLE_GALAXY_API_KEY` secret configured? |
-| Version bump didn't happen | Was the PR from a branch matching the allowed pattern? `chore/` branches intentionally skip the bump. |
-
 - [ ] `galaxy.yml` version matches the GitHub Release tag
 - [ ] Collection is available on Ansible Galaxy (`calaviaorg.setup`)
 - [ ] EE image is updated on GHCR (`ghcr.io/calavia-org/ansible-ee-setup:<tag>`)
@@ -87,7 +86,7 @@ Target branches allowed for PRs: `main`, `release/*`.
 | Issue | Check |
 |-------|-------|
 | Release didn't trigger | Did `galaxy.yml` change in the push to `main`? |
-| EE image push failed | Is `--container-runtime docker` set in `ansible-builder build`? |
+| EE image push failed | Is `ansible-builder` configured with `--container-runtime docker`? |
 | Galaxy publish failed | Is `ANSIBLE_GALAXY_API_KEY` secret configured? |
 | Version bump didn't happen | Was the PR from a branch matching the allowed pattern? `chore/` branches intentionally skip the bump. |
 
@@ -105,6 +104,7 @@ git push origin vX.Y.Z
 Then follow the release workflow steps manually:
 
 ```bash
+cd collections/ansible_collections/calaviaorg/setup
 ansible-galaxy collection build
 ansible-galaxy collection publish ./calaviaorg-setup-X.Y.Z.tar.gz
 ansible-builder build --container-runtime docker

--- a/SPEC-pr-check-and-bump.md
+++ b/SPEC-pr-check-and-bump.md
@@ -53,7 +53,7 @@ calavia-org/.github
 
 Consumer repo (e.g., ansible-collection-setup)
 └── .github/workflows/
-    └── pr-check-and-bump.yml           # Calls calavia-org/workflows-lib/.github/workflows/pr-check-and-bump.yml@main
+    └── pr-check-and-bump.yml           # Calls calavia-org/workflows-lib/.github/workflows/pr-check-and-bump.yml@v0
 ```
 
 ## 3. Reusable Workflow Design (`workflows-lib`)
@@ -66,7 +66,7 @@ workflow_call:
     allowed-branch-pattern:
       description: "Regex for allowed branch names"
       type: string
-      default: "^(major|feat|fix|doc)/.+"
+      default: "^(major|feat|fix|doc|chore)/.+"
     version-file:
       description: "Path to the version file (auto-detected if not provided)"
       type: string
@@ -97,11 +97,11 @@ workflow_call:
   4. **Get latest tag from base branch:** `git describe --tags --abbrev=0 origin/${{ github.base_ref }}`.
   5. **Bump version using custom action:**
      ```yaml
-     - uses: calavia-org/bump-version-action@v1
-       with:
-         version-file: ${{ inputs.version-file }}
-         bump-type: ${{ needs.check-pr.outputs.bump_type }}
-         current-version: ${{ steps.current.outputs.version }}
+      - uses: calavia-org/bump-version-action@v0
+        with:
+          version-file: ${{ inputs.version-file }}
+          bump-type: ${{ needs.check-pr.outputs.bump_type }}
+          current-version: ${{ steps.current.outputs.version }}
      ```
   6. **Check for changes and last commit** (same logic as current).
   7. **Commit and push** version bump to PR branch.
@@ -173,9 +173,10 @@ on:
 
 jobs:
   pr-check-and-bump:
-    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-bump.yml@main
+    uses: calavia-org/workflows-lib/.github/workflows/pr-check-and-bump.yml@v0
     with:
-      allowed-branch-pattern: "^(major|feat|fix|doc)/.+"
+      allowed-branch-pattern: "^(major|feat|fix|doc|chore)/.+"
+      no-bump-branch-pattern: "^chore/.+"
       # version-file: "auto"  # optional, auto-detected by default
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -194,15 +195,16 @@ jobs:
 
 ### Phase 3: Migrate consumer repos
 1. **`ansible-collection-setup`:**
-   - Delete `.github/workflows/check_branch_name.yml`.
-   - Delete `.github/workflows/auto-bump-version.yml`.
-   - Create `.github/workflows/pr-check-and-bump.yml` calling the reusable workflow.
+   - ✅ Create `.github/workflows/pr-check-and-bump.yml` calling the reusable workflow.
+   - ✅ Create `.github/workflows/pr-check-and-test.yml` calling the reusable test workflow.
+   - ✅ Create `.github/workflows/release-artifacts.yml` calling the reusable release workflow.
+   - ✅ Deprecated old workflows (`pr.yml`, `release.yml`).
 2. **`base-template`:**
    - Update `pull-request.yml` to include the reusable workflow call.
 3. Other repos: Add the caller workflow as needed.
 
 ### Phase 4: Deprecate old workflows
-1. After all repos are migrated, archive or delete old per-repo workflows.
+1. ✅ After all repos are migrated, archive or delete old per-repo workflows.
 
 ## 8. Decisions Made
 
@@ -215,21 +217,21 @@ jobs:
 
 ## 9. Risks and Mitigations
 
-## 9. Risks and Mitigations
-
 | Risk | Mitigation |
 |---|---|
-| Reusable workflow changes break all repos | Pin to major version tags (`@v1`) instead of `@main` |
+| Reusable workflow changes break all repos | Pin to major version tags (`@v0`) instead of `@main` |
 | Auto-detection picks wrong version file | Allow explicit `version-file` override in caller |
 | Tag comparison on non-main branch fails gracefully | Default to `0.0.0` if no tags exist on base branch |
 | Race condition: two PRs bump simultaneously | Commit check (`already_bumped`) prevents duplicate commits |
 
 ## 10. Success Criteria
 
-- [x] `bump-version-action` custom action published to `calavia-org/bump-version-action@v1`.
-- [ ] `workflows-lib` has a reusable `pr-check-and-bump.yml` workflow using the action.
-- [ ] `.github` repo provides a caller template.
-- [ ] `ansible-collection-setup` uses the reusable workflow and deletes old ones.
-- [ ] A PR to `main` correctly bumps version based on tags on `main`.
-- [ ] A PR to `release/v1.x` correctly bumps version based on tags on `release/v1.x`.
-- [ ] Branch names like `feat/new-feature` pass; `random-name` fails.
+- [x] `bump-version-action` custom action published to `calavia-org/bump-version-action@v0`.
+- [x] `workflows-lib` has a reusable `pr-check-and-bump.yml` workflow using the action.
+- [x] `workflows-lib` has a reusable `pr-check-and-test.yml` workflow.
+- [x] `workflows-lib` has a reusable `release-artifacts.yml` workflow.
+- [x] `.github` repo provides a caller template.
+- [x] `ansible-collection-setup` uses the reusable workflows and deprecated old ones.
+- [x] A PR to `main` correctly bumps version based on tags on `main`.
+- [x] A PR to `release/v1.x` correctly bumps version based on tags on `release/v1.x`.
+- [x] Branch names like `feat/new-feature` pass; `random-name` fails.

--- a/collections/ansible_collections/calaviaorg/setup/galaxy.yml
+++ b/collections/ansible_collections/calaviaorg/setup/galaxy.yml
@@ -8,7 +8,7 @@ namespace: calaviaorg
 name: setup
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.5.1
+version: 1.5.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Summary

Updates documentation that had become obsolete after the migration to centralized reusable workflows from .

## Changes

- **README.md**: 
  - Fixed Quick Start tox command ( →  — the  environment is skipped in )
  - Added CI / Workflows table documenting active workflows
  
- **CONTRIBUTING.md**: Rewrote from broken single-line stub to full contribution guide with branch naming, commit conventions, and local testing instructions

- **RELEASE.md**: 
  - Updated to reference  and  instead of the deprecated 
  - Removed duplicate troubleshooting section
  - Cleaned up workflow descriptions

- **SPEC-pr-check-and-bump.md**: 
  - Updated all workflow references from  to 
  - Updated  from  to 
  - Fixed duplicate "9. Risks and Mitigations" section
  - Marked all completed success criteria as done
  - Updated branch pattern to include 
  - Added  to caller template

## Why

This doc update also serves as a validation trigger for the recently merged fix in  (PR #12) that removed invalid  from the composite action. The PR workflows will confirm the fix is working correctly.