### PR TITLE
chore: add .omo/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage.*
 .pytest_cache
 .tox/
 .venv/
+.omo/
 
 # Directories
 **/__pycache__


### PR DESCRIPTION
## Summary
- Added  directory to 
- This directory contains internal OpenCode files (plans, drafts, evidence, notepads) that should not be tracked in version control

## Changes
- : Added  to the hidden directories section

## Testing
- [x] Pre-commit hooks passed
- [x] No functional changes (gitignore only)